### PR TITLE
Version 3 of flake8 contains breaking changes, so pin requirement.

### DIFF
--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 
+flake8==2.5.4
 pytest==2.8.2
 pytest-cov==2.2.0
 pytest-flake8==0.2


### PR DESCRIPTION
To see the problem, clear out your tox cache and rebuild.

    rm -rf .tox
    tox

I got a bunch of errors hinting at flake8, and I found that flake8 version 3 has some [breaking changes]. This change just pins the requirement at the version you probably used when you first set up `pytest-flake8`.

[breaking changes]: https://github.com/tholo/pytest-flake8/issues/7