### PR TITLE
Mocked querysets aggregation now handles None values.

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -111,14 +111,18 @@ def MockSet(*initial_items, **kwargs):
 
     def aggregate(expr):
         # TODO: Support multi expressions in aggregate functions
-        values = [getattr(x, expr.source_expressions[0].name) for x in items]
-        result = {
-            AGGREGATES_SUM: lambda: sum(values),
-            AGGREGATES_COUNT: lambda: len(values),
-            AGGREGATES_MAX: lambda: max(values),
-            AGGREGATES_MIN: lambda: min(values),
-            AGGREGATES_AVG: lambda: sum(values) / len(values)
-        }[expr.function]()
+        values = [y for y in [getattr(x, expr.source_expressions[0].name) for x in items] if y is not None]
+        result = None
+        if len(values) > 0:
+            result = {
+                AGGREGATES_SUM: lambda: sum(values),
+                AGGREGATES_COUNT: lambda: len(values),
+                AGGREGATES_MAX: lambda: max(values),
+                AGGREGATES_MIN: lambda: min(values),
+                AGGREGATES_AVG: lambda: sum(values) / len(values)
+            }[expr.function]()
+        if len(values) == 0 and expr.function == AGGREGATES_COUNT:
+            result = 0
 
         output_field = '{0}__{1}'.format(expr.source_expressions[0].name, expr.function).lower()
 


### PR DESCRIPTION
While using django-mock-queries for aggregation testing, I faced problems when trying to mock instances with None values in fields. I define mock instances like this:

> first_product=MockModel(price = 2)
> second_product=MockModel(price=4)
> none_product=MockModel(price=None)

Built-in functions like min() raise an exception when there is a None value in values list.

Now mock_set.aggregate()  more precisely mimics Django behaviour when working with None values in fields:
- Sum, Max, Min return None by default, and work only with not None values
- Avg divident is sum of not None values, divisor is len() of not None values
- Count returns 0 by default and works only with not None values.
