### PR TITLE
added spec_set to MockModel

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -228,8 +228,8 @@ def MockSet(*initial_items, **kwargs):
     return mock_set
 
 
-def MockModel(cls=None, mock_name=None, **attrs):
-    mock_attrs = dict(spec=cls, name=mock_name)
+def MockModel(cls=None, mock_name=None, spec_set=None, **attrs):
+    mock_attrs = dict(spec=cls, name=mock_name, spec_set=spec_set)
     mock_model = MagicMock(**mock_attrs)
 
     if mock_name:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 from mock import patch, MagicMock
 from unittest import TestCase
 
-from django_mock_queries import utils, constants
+from django_mock_queries import utils, constants, query
 
 
 class TestUtils(TestCase):
@@ -59,6 +59,12 @@ class TestUtils(TestCase):
         value, comparison = utils.get_attribute(obj, 'foo', default_value)
         assert value == default_value
         assert comparison is None
+
+    def test_get_attribute_raises_exception_when_spec_set_is_true(self):
+        obj = query.MockModel(spec_set=True, foo='foo_value')
+        assert getattr(obj, 'bar', None) is None
+        with self.assertRaises(AttributeError):
+            getattr(obj, 'bar')
 
     def test_is_match_equality_check_when_comparison_none(self):
         result = utils.is_match(1, 1)


### PR DESCRIPTION
Just a little addition to MockModel for testing functions that use getattr().
If you define your MockModel like this:
>mock_instance = MockModel(spec_set=True, some_field='some_value')

and try to getattr(mock_instance, 'bad_field') in function that you test it will throw an exception, not add this attribute to MockModel instance.