### PR TITLE
field_names() function call is skipped if spec_set=True

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -232,6 +232,10 @@ def MockSet(*initial_items, **kwargs):
 
 
 def MockModel(cls=None, mock_name=None, spec_set=None, **attrs):
+    """
+    Be aware that spec_set=True can be used only when mocking models that are not based on real Django project models.
+    Always check "if not hasattr(obj, '_spec_set'):" if there is an access to Django model class member (e. g. "_meta")
+    """
     mock_attrs = dict(spec=cls, name=mock_name, spec_set=spec_set)
     mock_model = MagicMock(**mock_attrs)
 

--- a/django_mock_queries/utils.py
+++ b/django_mock_queries/utils.py
@@ -33,13 +33,14 @@ def get_attribute(obj, attr, default=None):
         elif result is None:
             break
         else:
-            field_names = find_field_names(result)
-            if p != 'pk' and field_names and p not in field_names:
-                message = "Cannot resolve keyword '{}' into field. Choices are {}.".format(
-                    p,
-                    ', '.join(map(repr, map(str, field_names)))
-                )
-                raise FieldError(message)
+            if not hasattr(obj, '_spec_set'):
+                field_names = find_field_names(result)
+                if p != 'pk' and field_names and p not in field_names:
+                    message = "Cannot resolve keyword '{}' into field. Choices are {}.".format(
+                        p,
+                        ', '.join(map(repr, map(str, field_names)))
+                    )
+                    raise FieldError(message)
             result = getattr(result, p, None)
 
     value = result if result is not None else default

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -60,8 +60,14 @@ class TestUtils(TestCase):
         assert value == default_value
         assert comparison is None
 
-    def test_get_attribute_raises_exception_when_spec_set_is_true(self):
-        obj = query.MockModel(spec_set=True, foo='foo_value')
+    def test_get_attribute_returns_value_when_spec_set_is_true(self):
+        obj = query.MockModel(spec_set=True, foo='foo')
+        value, comparison = utils.get_attribute(obj, 'foo')
+        assert value == 'foo'
+        assert comparison is None
+
+    def test_getattr_builtin_raises_exception_when_spec_set_is_true(self):
+        obj = query.MockModel(spec_set=True, foo='foo')
         assert getattr(obj, 'bar', None) is None
         with self.assertRaises(AttributeError):
             getattr(obj, 'bar')


### PR DESCRIPTION
I propose that find_field_names function has to be skipped in this specific case:
1. Mocked model has spec_set=True.
2. Mocked model cls is not a real Django project model.

In project i work on there are Django queryset functions calls but it is not a Django project itself. So i want to populate mock set with MockModel instances. Still can't use e. g. filter() because of find_field_names call which fails because ofc there is no _meta attribute on MockModel instance.

- [ ] Check if queryset.model in this code in mocks.py can anyhow receive spec_set=True as param. Any suggestions?
>         result.execute_sql.side_effect = NotSupportedError(
>             "Mock database tried to execute SQL for {} model.".format(
>                 queryset.model._meta.object_name))
