### PR TITLE
values() and values_list()

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -31,20 +31,7 @@ def MockSet(*initial_items, **kwargs):
         'select_for_update'
     ])
     mock_set.cls = clone.cls if clone else kwargs.get('cls', empty_func)
-    mock_set.flat = clone.flat if clone else None
-    mock_set.projection = clone.projection if clone else None
     mock_set.count = MagicMock(side_effect=lambda: len(items))
-
-    def project(index, source_items=None):
-        target_items = source_items or items
-        if not mock_set.projection:
-            return target_items[index]
-        elif mock_set.flat:
-            return getattr(target_items[index], mock_set.projection[0])
-        else:
-            return tuple([getattr(target_items[index], x) for x in mock_set.projection])
-
-    mock_set.project = MagicMock(side_effect=project)
 
     def add(*model):
         items.extend(model)
@@ -105,7 +92,7 @@ def MockSet(*initial_items, **kwargs):
     mock_set.exists = MagicMock(side_effect=exists)
 
     def get_item(x):
-        return project(x)
+        return items[x]
 
     mock_set.__getitem__ = MagicMock(side_effect=get_item)
 
@@ -153,7 +140,7 @@ def MockSet(*initial_items, **kwargs):
         results = sorted(items, key=attrgetter(field), reverse=True)
         if len(results) == 0:
             raise ObjectDoesNotExist()
-        return project(0, source_items=results)
+        return results[0]
 
     mock_set.latest = MagicMock(side_effect=latest)
 
@@ -161,7 +148,7 @@ def MockSet(*initial_items, **kwargs):
         results = sorted(items, key=attrgetter(field))
         if len(results) == 0:
             raise ObjectDoesNotExist()
-        return project(0, source_items=results)
+        return results[0]
 
     mock_set.earliest = MagicMock(side_effect=earliest)
 
@@ -177,7 +164,7 @@ def MockSet(*initial_items, **kwargs):
     mock_set.last = MagicMock(side_effect=last)
 
     def __iter__():
-        return iter([project(i) for i, v in enumerate(items)])
+        return iter([items[i] for i, v in enumerate(items)])
 
     mock_set.__iter__ = MagicMock(side_effect=__iter__)
 
@@ -198,7 +185,7 @@ def MockSet(*initial_items, **kwargs):
         elif results.count() > 1:
             raise MultipleObjectsReturned()
         else:
-            return project(0, source_items=results)
+            return results[0]
 
     mock_set.get = MagicMock(side_effect=get)
 
@@ -209,7 +196,7 @@ def MockSet(*initial_items, **kwargs):
         elif results.count() > 1:
             raise MultipleObjectsReturned()
         else:
-            return project(0, source_items=results), False
+            return results[0], False
 
     mock_set.get_or_create = MagicMock(side_effect=get_or_create)
 
@@ -220,13 +207,45 @@ def MockSet(*initial_items, **kwargs):
             raise TypeError('Unexpected keyword arguments to values_list: %s' % (list(kwargs),))
         if flat and len(fields) > 1:
             raise TypeError('`flat` is not valid when values_list is called with more than one field.')
+        if len(fields) == 0:
+            raise NotImplementedError('values_list() with no arguments is not implemented')
 
-        mock_set.flat = flat
-        mock_set.projection = fields
+        result = []
+        if fields:
+            for item in items:
+                a = list()
+                for field in fields:
+                    if field not in item.mock_concrete_fields:
+                        raise AttributeError('Mocked model %s has no field %s' % (item, field))
+                    a.append(getattr(item, field))
+                if flat:
+                    result.append(a[0])
+                else:
+                    result.append(tuple(a))
 
-        return MockSet(*items, clone=mock_set)
+        return MockSet(*result, clone=mock_set)
 
     mock_set.values_list = MagicMock(side_effect=values_list)
+
+    def values(*fields):
+        result = []
+        for item in items:
+            if len(fields) == 0:
+                item_dict = {}
+                for field in item.mock_concrete_fields:
+                    item_dict[field] = getattr(item, field)
+                result.append(item_dict)
+            else:
+                item_dict = {}
+                for field in fields:
+                    if field not in item.mock_concrete_fields:
+                        raise AttributeError('Mocked model %s has no field %s' % (item, field))
+                    item_dict[field] = getattr(item, field)
+                result.append(item_dict)
+
+        return MockSet(*result, clone=mock_set)
+
+    mock_set.values = MagicMock(side_effect=values)
 
     return mock_set
 
@@ -240,6 +259,9 @@ def MockModel(cls=None, mock_name=None, spec_set=None, **attrs):
 
     for key, value in attrs.items():
         setattr(type(mock_model), key, PropertyMock(return_value=value))
+
+    mock_concrete_fields = [x for x in attrs.keys()]
+    setattr(type(mock_model), 'mock_concrete_fields', PropertyMock(return_value=mock_concrete_fields))
 
     return mock_model
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -18,35 +18,6 @@ class TestQuery(TestCase):
         items = [1, 2, 3]
         assert MockSet(*items).count() == len(items)
 
-    def test_query_project_returns_whole_item_by_index(self):
-        item_1 = MockModel(foo=1)
-        item_2 = MockModel(foo=2)
-
-        qs = MockSet(item_1, item_2)
-        assert qs.project(1) == item_2
-
-    def test_query_project_returns_item_flat_attribute(self):
-        item_1 = MockModel(foo=1)
-        item_2 = MockModel(foo=2)
-
-        qs = MockSet(item_1, item_2)
-        qs.flat = True
-        qs.projection = ['foo']
-
-        assert qs.project(1) == item_2.foo
-
-    def test_query_project_returns_item_specified_attributes_tuple(self):
-        item_1 = MockModel(foo=1, bar='a')
-        item_2 = MockModel(foo=2, bar='b')
-
-        qs = MockSet(item_1, item_2)
-        qs.flat = False
-        qs.projection = ['foo', 'bar']
-
-        attrs = qs.project(1)
-        assert attrs[0] == item_2.foo
-        assert attrs[1] == item_2.bar
-
     def test_query_adds_items_to_set(self):
         items = [1, 2, 3]
         self.mock_set.add(*items)
@@ -548,13 +519,51 @@ class TestQuery(TestCase):
         qs = MockSet(MockModel(foo=1), MockModel(foo=2))
         self.assertRaises(TypeError, qs.values_list, 'foo', 'bar', flat=True)
 
-    def test_query_values_list_returns_qs_clone_with_flat_and_projection_fields_set(self):
-        item_1 = MockModel(foo=1)
-        item_2 = MockModel(foo=2)
+    def test_query_values_list_raises_attribute_error_when_field_is_not_in_mock_concrete_fields(self):
+        qs = MockSet(MockModel(foo=1), MockModel(foo=2))
+        self.assertRaises(AttributeError, qs.values_list, 'bar')
+
+    def test_query_values_list_raises_not_implemented_if_no_fields_specified(self):
+        qs = MockSet(MockModel(foo=1), MockModel(foo=2))
+        self.assertRaises(NotImplementedError, qs.values_list)
+
+    def test_query_values_list(self):
+        item_1 = MockModel(foo=1, bar=3)
+        item_2 = MockModel(foo=2, bar=4)
 
         qs = MockSet(item_1, item_2)
-        projection = ('foo',)
-        obj = qs.values_list(*projection, flat=True)
+        results_flat = qs.values_list('foo', flat=True)
+        results_single_fields = qs.values_list('foo')
+        results_with_fields = qs.values_list('foo', 'bar')
 
-        assert obj.flat is True
-        assert obj.projection == projection
+        assert results_flat[0] == 1
+        assert results_flat[1] == 2
+        assert results_single_fields[0] == (1,)
+        assert results_single_fields[1] == (2,)
+        assert results_with_fields[0] == (1, 3)
+        assert results_with_fields[1] == (2, 4)
+
+    def test_query_values_raises_attribute_error_when_field_is_not_in_mock_concrete_fields(self):
+        qs = MockSet(MockModel(foo=1), MockModel(foo=2))
+        self.assertRaises(AttributeError, qs.values, 'bar')
+
+    def test_query_values(self):
+        item_1 = MockModel(foo=1, bar=3, foobar=5)
+        item_2 = MockModel(foo=2, bar=4, foobar=6)
+
+        qs = MockSet(item_1, item_2)
+
+        results_all = qs.values()
+        results_with_fields = qs.values('foo', 'bar')
+
+        assert results_all[0]['foo'] == 1
+        assert results_all[0]['bar'] == 3
+        assert results_all[0]['foobar'] == 5
+        assert results_all[1]['foo'] == 2
+        assert results_all[1]['bar'] == 4
+        assert results_all[1]['foobar'] == 6
+
+        assert results_with_fields[0]['foo'] == 1
+        assert results_with_fields[0]['bar'] == 3
+        assert results_with_fields[1]['foo'] == 2
+        assert results_with_fields[1]['bar'] == 4


### PR DESCRIPTION
I've decided to add mock_concrete_fields PropertyMock to MockModel, removed project() function from MockSet(), added values() and changed values_list() functions. Mocked queryset can still be iterated, and there seem to be no problems when using item[x] instead of project(x) in get_item() function.