### PR TITLE
Add mocked_relations decorator for all related models.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,22 @@ matrix:
   include:
     - python: 2.7
       env:
-      - TOX_ENV=py27
+      - TOX_ENV=py27-dj18
+      - TOX_ENV=py27-dj19
+      - TOX_ENV=py27-dj110
     - python: 3.3
       env:
-      - TOX_ENV=py33
+      - TOX_ENV=py33-dj18
     - python: 3.4
       env:
-      - TOX_ENV=py34
+      - TOX_ENV=py34-dj18
+      - TOX_ENV=py34-dj19
+      - TOX_ENV=py34-dj110
     - python: 3.5
       env:
-      - TOX_ENV=py35
+      - TOX_ENV=py35-dj18
+      - TOX_ENV=py35-dj19
+      - TOX_ENV=py35-dj110
 
 install:
   - travis_retry pip install "virtualenv<14.0.0" "tox>=1.9" "coverage<4"

--- a/django_mock_queries/mocks.py
+++ b/django_mock_queries/mocks.py
@@ -1,12 +1,18 @@
-from mock import MagicMock
+from mock import Mock, MagicMock, patch
+from functools import partial
+from itertools import chain
 import os
 import sys
+import weakref
 
 import django
 from django.apps import apps
 from django.db import connections
 from django.db.backends.base import creation
+from django.db.models import Model
 from django.db.utils import ConnectionHandler, NotSupportedError
+
+from .query import MockSet
 
 
 def monkey_patch_test_db(disabled_features=None):
@@ -88,3 +94,212 @@ def mock_django_connection(disabled_features=None):
     mock_ops.compiler.return_value.side_effect = compiler
     mock_ops.integer_field_range.return_value = (-sys.maxsize - 1, sys.maxsize)
     mock_ops.max_name_length.return_value = sys.maxsize
+
+    Model.refresh_from_db = Mock()  # Make this into a noop.
+
+
+class MockOneToManyMap(object):
+    def __init__(self, original):
+        """ Wrap a mock mapping around the original one-to-many relation. """
+        self.map = {}
+        self.original = original
+
+    def __get__(self, instance, owner):
+        """ Look in the map to see if there is a related set.
+
+        If not, create a new set.
+        """
+
+        if instance is None:
+            # Call was to the class, not an object.
+            return self
+
+        instance_id = id(instance)
+        entry = self.map.get(instance_id)
+        old_instance = related_objects = None
+        if entry is not None:
+            old_instance_weak, related_objects = entry
+            old_instance = old_instance_weak()
+        if entry is None or old_instance is None:
+            related = getattr(self.original, 'related', self.original)
+            related_objects = MockSet(cls=related.field.model)
+            self.__set__(instance, related_objects)
+
+        return related_objects
+
+    def __set__(self, instance, value):
+        """ Set a related object for an instance. """
+
+        self.map[id(instance)] = (weakref.ref(instance), value)
+
+    def __getattr__(self, name):
+        """ Delegate all other calls to the original. """
+
+        return getattr(self.original, name)
+
+
+class MockOneToOneMap(object):
+    def __init__(self, original):
+        """ Wrap a mock mapping around the original one-to-one relation. """
+        self.map = {}
+        self.original = original
+
+    def __get__(self, instance, owner):
+        """ Look in the map to see if there is a related object.
+
+        If not (the default) raise the expected exception.
+        """
+
+        if instance is None:
+            # Call was to the class, not an object.
+            return self
+
+        entry = self.map.get(id(instance))
+        old_instance = related_object = None
+        if entry is not None:
+            old_instance_weak, related_object = entry
+            old_instance = old_instance_weak()
+        if entry is None or old_instance is None:
+            raise self.original.RelatedObjectDoesNotExist(
+                "Mock %s has no %s." % (
+                    owner.__name__,
+                    self.original.related.get_accessor_name()
+                )
+            )
+        return related_object
+
+    def __set__(self, instance, value):
+        """ Set a related object for an instance. """
+
+        self.map[id(instance)] = (weakref.ref(instance), value)
+
+    def __getattr__(self, name):
+        """ Delegate all other calls to the original. """
+
+        return getattr(self.original, name)
+
+
+def find_all_models(models):
+    """ Yield all models and their parents. """
+    for model in models:
+        yield model
+        # noinspection PyProtectedMember
+        for parent in model._meta.parents.keys():
+            for parent_model in find_all_models((parent,)):
+                yield parent_model
+
+
+# noinspection PyProtectedMember
+def mocked_relations(*models):
+    """ Mock all related field managers to make pure unit tests possible.
+
+    The resulting patcher can be used just like one from the mock module:
+    As a test method decorator, a test class decorator, a context manager,
+    or by just calling start() and stop().
+
+    @mocked_relations(Dataset):
+    def test_dataset(self):
+        dataset = Dataset()
+        check = dataset.content_checks.create()  # returns a ContentCheck object
+    """
+    # noinspection PyUnresolvedReferences
+    patch_object = patch.object
+    patchers = []
+    for model in find_all_models(models):
+        if isinstance(model.save, Mock):
+            # already mocked, so skip it
+            continue
+        model_name = model._meta.object_name
+        patchers.append(patch_object(model, 'save', new_callable=partial(
+            Mock,
+            name=model_name + '.save')))
+        if hasattr(model, 'objects'):
+            patchers.append(patch_object(model, 'objects', new_callable=partial(
+                MockSet,
+                mock_name=model_name + '.objects',
+                cls=model)))
+        for related_object in chain(model._meta.related_objects,
+                                    model._meta.many_to_many):
+            name = related_object.name
+            if name not in model.__dict__ and related_object.one_to_many:
+                name += '_set'
+            if name in model.__dict__:
+                # Only mock direct relations, not inherited ones.
+                old_relation = getattr(model, name, None)
+                if old_relation is not None:
+                    if related_object.one_to_one:
+                        new_callable = partial(MockOneToOneMap, old_relation)
+                    else:
+                        new_callable = partial(MockOneToManyMap, old_relation)
+                    patchers.append(patch_object(model,
+                                                 name,
+                                                 new_callable=new_callable))
+    return PatcherChain(patchers, pass_mocks=False)
+
+
+class PatcherChain(object):
+    """ Chain a list of mock patchers into one.
+
+    The resulting patcher can be used just like one from the mock module:
+    As a test method decorator, a test class decorator, a context manager,
+    or by just calling start() and stop().
+    """
+    def __init__(self, patchers, pass_mocks=True):
+        """ Initialize a patcher.
+
+        :param patchers: a list of patchers that should all be applied
+        :param pass_mocks: True if any mock objects created by the patchers
+        should be passed to any decorated test methods.
+        """
+        self.patchers = patchers
+        self.pass_mocks = pass_mocks
+
+    def __call__(self, func):
+        if isinstance(func, type):
+            return self.decorate_class(func)
+        return self.decorate_callable(func)
+
+    def decorate_class(self, cls):
+        for attr in dir(cls):
+            # noinspection PyUnresolvedReferences
+            if not attr.startswith(patch.TEST_PREFIX):
+                continue
+
+            attr_value = getattr(cls, attr)
+            if not hasattr(attr_value, "__call__"):
+                continue
+
+            setattr(cls, attr, self(attr_value))
+        return cls
+
+    def decorate_callable(self, target):
+        """ Called as a decorator. """
+
+        # noinspection PyUnusedLocal
+        def absorb_mocks(test_case, *args):
+            return target(test_case)
+
+        should_absorb = not (self.pass_mocks or isinstance(target, type))
+        result = absorb_mocks if should_absorb else target
+        for patcher in self.patchers:
+            result = patcher(result)
+        return result
+
+    def __enter__(self):
+        """ Starting a context manager.
+
+        All the patched objects are passed as a list to the with statement.
+        """
+        return [patcher.__enter__() for patcher in self.patchers]
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """ Ending a context manager. """
+        for patcher in self.patchers:
+            patcher.__exit__(exc_type, exc_val, exc_tb)
+
+    def start(self):
+        return [patcher.start() for patcher in self.patchers]
+
+    def stop(self):
+        for patcher in reversed(self.patchers):
+            patcher.stop()

--- a/examples/users/analytics/tests.py
+++ b/examples/users/analytics/tests.py
@@ -1,7 +1,7 @@
 """ Example of mocking the database and using django_mock_queries.
 
 There are two kinds of test cases here: TestApi is a regular Django
-test that uses the database. TestViews and TestMockedApi use MockSet
+test that uses the database. The others use MockSet and mocked_relations
 to simulate QuerySets in memory, so they're much faster than regular Django
 tests. You can even run them without creating a database by using the
 settings_mocked module.
@@ -12,9 +12,9 @@ if the database is mocked. Use this decorator:
 """
 
 from datetime import date, timedelta
-from mock import patch
 
-from django_mock_queries.query import MockSet, MockModel
+from django_mock_queries.query import MockModel
+from django_mock_queries.mocks import mocked_relations
 from django.contrib.auth.models import User
 from django.test import TestCase, skipIfDBFeature
 from model_mommy import mommy
@@ -33,43 +33,35 @@ class TestApi(TestCase):
         self.assertEqual(start_count+1, final_count)
 
 
+@mocked_relations(User)
 class TestViews(TestCase):
-    @patch('analytics.api.AnalyticsApi.active_users')
-    def test_views_active_users_contains_usernames_separated_by_comma(self, active_users_mock):
-        mock_users = []
+    def test_views_active_users_contains_usernames_separated_by_comma(self):
         for i in range(5):
-            mock_users.append(MockModel(username='user_%d' % i))
+            User.objects.add(MockModel(username='user_%d' % i,
+                                       is_active=True))
 
-        active_users_mock.return_value = mock_users
         response = views.active_users()
 
-        expected = ', '.join([x.username for x in mock_users])
+        expected = ', '.join([x.username for x in User.objects.all()])
         self.assertEqual(expected, response.content.decode('utf-8'))
 
 
+@mocked_relations(User)
 class TestMockedApi(TestCase):
-    users = MockSet(cls=User)
-    user_save = patch('django.contrib.auth.models.User.save')
-    user_objects = patch('django.contrib.auth.models.User.objects', users)
-
     def setUp(self):
         self.api = AnalyticsApi()
-        self.users.clear()
 
-    @user_objects
     def test_api_active_users_filters_by_is_active_true(self):
         active_user = MockModel(mock_name='active user', is_active=True)
         inactive_user = MockModel(mock_name='inactive user', is_active=False)
 
-        self.users.add(*[active_user, inactive_user])
+        User.objects.add(*[active_user, inactive_user])
         results = [x for x in self.api.active_users()]
 
         assert active_user in results
         assert inactive_user not in results
 
-    @user_save
-    @user_objects
-    def test_api_create_user(self, save_mock):
+    def test_api_create_user(self):
         attrs = dict((k, v) for (k, v) in mommy.prepare(User).__dict__.items() if k[0] != '_')
         user = self.api.create_user(**attrs)
         assert isinstance(user, User)
@@ -77,9 +69,9 @@ class TestMockedApi(TestCase):
         for k, v in attrs.items():
             assert getattr(user, k) == v
 
-        assert save_mock.call_count == 1
+        # noinspection PyUnresolvedReferences
+        assert User.save.call_count == 1
 
-    @user_objects
     def test_api_today_visitors_counts_todays_logins(self):
         past_visitors = [
             MockModel(last_login=(date.today() - timedelta(days=1))),
@@ -90,17 +82,17 @@ class TestMockedApi(TestCase):
             MockModel(last_login=date.today()),
             MockModel(last_login=date.today())
         ]
-        self.users.add(*(past_visitors + today_visitors))
+        User.objects.add(*(past_visitors + today_visitors))
         count = self.api.today_visitors_count()
         assert count == len(today_visitors)
 
-    # Comment out these two decorators to see what happens when you forget to
-    # mock some database access. It should work under "./manage.py test", but
-    # raise a helpful error when run with "--settings=users.settings_mocked".
-    # noinspection PyUnusedLocal
-    @user_save
-    @user_objects
-    def test_create(self, save_mock=None):
+
+# Comment out this decorator to see what happens when you forget to
+# mock some database access. It should work under "./manage.py test", but
+# raise a helpful error when run with "--settings=users.settings_mocked".
+@mocked_relations(User)
+class TestMockedUser(TestCase):
+    def test_create(self):
         start_count = User.objects.count()
 
         User.objects.create(username='bob')

--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -7,7 +7,7 @@
 click==6.6                # via pip-tools
 configparser==3.5.0       # via flake8
 coverage==3.7.1
-Django==1.8.12            # via model-mommy
+# Django==1.8.12            # via model-mommy, manually excluded for tox
 djangorestframework==3.3.2
 enum34==1.1.6             # via flake8
 first==2.0.1              # via pip-tools

--- a/tests/mock_models.py
+++ b/tests/mock_models.py
@@ -25,6 +25,11 @@ class Sedan(Car):
     pass
 
 
+class Passenger(models.Model):
+    car = models.ForeignKey(Car, related_name='passengers')
+    name = models.CharField(max_length=25)
+
+
 class CarSerializer(serializers.ModelSerializer):
     make = ManufacturerSerializer()
     speed = serializers.SerializerMethodField()

--- a/tests/test_asserts.py
+++ b/tests/test_asserts.py
@@ -1,7 +1,8 @@
 from mock import patch
 from model_mommy import mommy
-from unittest import TestCase
+from unittest import TestCase, skipIf
 
+import django
 from django_mock_queries.asserts import assert_serializer, SerializerAssert
 from tests.mock_models import Car, CarSerializer, Manufacturer
 
@@ -90,6 +91,8 @@ class TestQuery(TestCase):
         sa = self.serializer_assert.instance(self.car_model).returns(*values.keys()).values(**values)
         sa.run()
 
+    @skipIf(django.VERSION[:2] >= (1, 10),
+            "Django 1.10 refreshes deleted fields from the database.")
     def test_serializer_assert_run_skips_check_for_null_field_excluded_from_serializer(self):
         delattr(self.car_model, 'model')
         sa = self.serializer_assert.instance(self.car_model).returns('model')

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -1,12 +1,17 @@
 from django.db import connection
 from django.db.utils import NotSupportedError
 from django.db.backends.base.creation import BaseDatabaseCreation
-from django_mock_queries.mocks import monkey_patch_test_db, mock_django_connection
-from mock import patch
+from django_mock_queries.mocks import monkey_patch_test_db, \
+    mock_django_connection, MockOneToOneMap, MockOneToManyMap, PatcherChain, mocked_relations
+from django_mock_queries.query import MockSet
+from mock import patch, MagicMock, PropertyMock
 from unittest import TestCase
+import sys
 
 from django_mock_queries import mocks
-from tests.mock_models import Car
+from tests.mock_models import Car, Sedan, Manufacturer
+
+BUILTINS = 'builtins' if sys.version_info[0] >= 3 else '__builtin__'
 
 
 class TestMocks(TestCase):
@@ -46,3 +51,277 @@ class TestMocks(TestCase):
 
         self.assertTrue(is_foo_before)
         self.assertFalse(is_foo_after)
+
+
+# noinspection PyUnresolvedReferences,PyStatementEffect
+class MockOneToOneTests(TestCase):
+    def test_not_mocked(self):
+        car = Car(id=99)
+
+        with self.assertRaises(NotSupportedError):
+            car.sedan
+
+    @patch.object(Car, 'sedan', MockOneToOneMap(Car.sedan))
+    def test_not_set(self):
+        car = Car(id=99)
+
+        with self.assertRaises(Car.sedan.RelatedObjectDoesNotExist):
+            car.sedan
+
+    @patch.object(Car, 'sedan', MockOneToOneMap(Car.sedan))
+    def test_set(self):
+        car = Car()
+        sedan = Sedan()
+        car.sedan = sedan
+
+        self.assertIs(car.sedan, sedan)
+
+    @patch.object(Car, 'sedan', MockOneToOneMap(Car.sedan))
+    def test_set_on_individual_object(self):
+        car = Car()
+        car2 = Car()
+        car.sedan = Sedan()
+
+        with self.assertRaises(Car.sedan.RelatedObjectDoesNotExist):
+            car2.sedan
+
+    @patch.object(Car, 'sedan', MockOneToOneMap(Car.sedan))
+    def test_delegation(self):
+        self.assertEqual(Car.sedan.cache_name, '_sedan_cache')
+
+
+# noinspection PyUnresolvedReferences,PyStatementEffect
+class MockOneToManyTests(TestCase):
+    def test_not_mocked(self):
+        m = Manufacturer()
+
+        with self.assertRaisesRegexp(
+                NotSupportedError,
+                'Mock database tried to execute SQL for Car model'):
+            m.car_set.count()
+
+    def test_mock_is_removed(self):
+        m = Manufacturer()
+
+        with patch.object(Manufacturer, 'car_set', MockOneToManyMap(Manufacturer.car_set)):
+            m.car_set = MockSet(Car(speed=95))
+            self.assertEqual(1, m.car_set.count())
+
+        with self.assertRaisesRegexp(
+                NotSupportedError,
+                'Mock database tried to execute SQL for Car model'):
+            m.car_set.count()
+
+    @patch.object(Manufacturer, 'car_set', MockOneToManyMap(Manufacturer.car_set))
+    def test_not_set(self):
+        m = Manufacturer()
+
+        self.assertEqual(0, m.car_set.count())
+
+    @patch.object(Manufacturer, 'car_set', MockOneToManyMap(Manufacturer.car_set))
+    def test_set(self):
+        m = Manufacturer()
+        car = Car(speed=95)
+        m.car_set.add(car)
+
+        self.assertIs(m.car_set.first(), car)
+
+    @patch.object(Manufacturer, 'car_set', MockOneToManyMap(Manufacturer.car_set))
+    def test_set_on_individual_object(self):
+        m = Manufacturer()
+        m.car_set.add(Car(speed=95))
+        m2 = Manufacturer()
+
+        self.assertEqual(0, m2.car_set.count())
+
+    @patch.object(Manufacturer, 'car_set', MockOneToManyMap(Manufacturer.car_set))
+    def test_set_explicit_collection(self):
+        m = Manufacturer()
+        m.car_set.add(Car(speed=95))
+
+        car = Car(speed=100)
+        m.car_set = MockSet(car)
+
+        self.assertIs(m.car_set.first(), car)
+
+    @patch.object(Manufacturer, 'car_set', MockOneToManyMap(Manufacturer.car_set))
+    @patch.object(Car, 'save', MagicMock)
+    def test_create(self):
+        m = Manufacturer()
+        car = m.car_set.create(speed=95)
+
+        self.assertIsInstance(car, Car)
+        self.assertEqual(95, car.speed)
+
+    @patch.object(Manufacturer, 'car_set', MockOneToManyMap(Manufacturer.car_set))
+    def test_delegation(self):
+        """ We can still access fields from the original relation manager. """
+        self.assertTrue(Manufacturer.car_set.related_manager_cls.do_not_call_in_templates)
+
+
+# noinspection PyUnusedLocal
+def zero_sum(items):
+    return 0
+
+
+class PatcherChainTest(TestCase):
+    patch_mock_max = patch(BUILTINS + '.max')
+    patch_zero_sum = patch(BUILTINS + '.sum', zero_sum)
+
+    @patch_zero_sum
+    def test_patch_dummy(self):
+        sum_result = sum([1, 2, 3])
+
+        self.assertEqual(0, sum_result)
+
+    @patch_mock_max
+    def test_patch_mock(self, mock_max):
+        mock_max.return_value = 42
+        max_result = max([1, 2, 3])
+
+        self.assertEqual(42, max_result)
+
+    @PatcherChain([patch_zero_sum, patch_mock_max])
+    def test_patch_both(self, mock_max):
+        sum_result = sum([1, 2, 3])
+        mock_max.return_value = 42
+        max_result = max([1, 2, 3])
+
+        self.assertEqual(0, sum_result)
+        self.assertEqual(42, max_result)
+
+    @PatcherChain([patch_mock_max, patch_zero_sum])
+    def test_patch_both_reversed(self, mock_max):
+        sum_result = sum([1, 2, 3])
+        mock_max.return_value = 42
+        max_result = max([1, 2, 3])
+
+        self.assertEqual(0, sum_result)
+        self.assertEqual(42, max_result)
+
+    @PatcherChain([patch_mock_max], pass_mocks=False)
+    def test_mocks_not_passed(self):
+        """ Create a new mock, but don't pass it to the test method. """
+
+    def test_context_manager(self):
+        with PatcherChain([PatcherChainTest.patch_mock_max,
+                           PatcherChainTest.patch_zero_sum]) as mocked:
+            sum_result = sum([1, 2, 3])
+            mocked[0].return_value = 42
+            max_result = max([1, 2, 3])
+
+            self.assertEqual(0, sum_result)
+            self.assertEqual(42, max_result)
+            self.assertEqual(2, len(mocked))
+            self.assertIs(zero_sum, mocked[1])
+
+    def test_start(self):
+        patcher = PatcherChain([PatcherChainTest.patch_mock_max,
+                                PatcherChainTest.patch_zero_sum])
+        mocked = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        sum_result = sum([1, 2, 3])
+        mocked[0].return_value = 42
+        max_result = max([1, 2, 3])
+
+        self.assertEqual(0, sum_result)
+        self.assertEqual(42, max_result)
+        self.assertEqual(2, len(mocked))
+        self.assertIs(zero_sum, mocked[1])
+
+
+@PatcherChain([patch(BUILTINS + '.max'), patch(BUILTINS + '.sum', zero_sum)],
+              pass_mocks=False)
+class PatcherChainOnClassTest(TestCase):
+    test_example_attribute = 42
+
+    def test_patch_dummy(self):
+        sum_result = sum([1, 2, 3])
+
+        self.assertEqual(0, sum_result)
+
+    def test_patch_mock(self):
+        max_result = max([1, 2, 3])
+
+        self.assertIsInstance(max_result, MagicMock)
+
+    def test_patch_both(self):
+        sum_result = sum([1, 2, 3])
+        max_result = max([1, 2, 3])
+
+        self.assertEqual(0, sum_result)
+        self.assertIsInstance(max_result, MagicMock)
+
+    def test_attribute(self):
+        self.assertEqual(42, PatcherChainOnClassTest.test_example_attribute)
+
+
+class MockedRelationsTest(TestCase):
+    @mocked_relations(Manufacturer)
+    def test_decorator(self):
+        m = Manufacturer()
+
+        self.assertEqual(0, m.car_set.count())
+        m.car_set.add(Car())
+        self.assertEqual(1, m.car_set.count())
+
+    def test_context_manager(self):
+        m = Manufacturer()
+
+        with mocked_relations(Manufacturer):
+            self.assertEqual(0, m.car_set.count())
+            m.car_set.add(Car())
+            self.assertEqual(1, m.car_set.count())
+
+    def test_reusing_patcher(self):
+        patcher = mocked_relations(Manufacturer)
+        with patcher:
+            self.assertEqual(0, Manufacturer.objects.count())
+            Manufacturer.objects.add(Manufacturer())
+            self.assertEqual(1, Manufacturer.objects.count())
+
+        with patcher:
+            self.assertEqual(0, Manufacturer.objects.count())
+            Manufacturer.objects.add(Manufacturer())
+            self.assertEqual(1, Manufacturer.objects.count())
+
+    @mocked_relations(Manufacturer)
+    def test_relation_with_garbage_collection(self):
+        self.longMessage = True
+        for group_index in range(10):
+            m = Manufacturer()
+            self.assertEqual(0,
+                             m.car_set.count(),
+                             'group_index: {}'.format(group_index))
+            m.car_set.add(Car())
+            self.assertEqual(1, m.car_set.count())
+            del m
+
+    def test_replaces_other_mocks(self):
+        original_type = type(Manufacturer.car_set)
+        self.assertIsInstance(Manufacturer.car_set, original_type)
+
+        with mocked_relations(Manufacturer):
+            Manufacturer.car_set = PropertyMock('Manufacturer.car_set')
+
+        self.assertIsInstance(Manufacturer.car_set, original_type)
+
+    @mocked_relations(Sedan)
+    def test_parent(self):
+        sedan = Sedan(speed=95)
+
+        self.assertEqual(0, sedan.passengers.count())
+
+    @mocked_relations(Sedan)
+    def test_mock_twice(self):
+        """ Don't reset the mocking if a class is mocked twice.
+
+        Could happen where Sedan is mocked on the class, and Car (the base
+        class) is mocked on a method.
+        """
+        Car.objects.add(Car(speed=95))
+        self.assertEqual(1, Car.objects.count())
+
+        with mocked_relations(Car):
+            self.assertEqual(1, Car.objects.count())

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -149,7 +149,7 @@ class TestQuery(TestCase):
         with self.assertRaisesRegexp(
                 FieldError,
                 r"Cannot resolve keyword 'bad_field' into field\. "
-                r"Choices are 'id', 'make', 'make_id', 'model', 'sedan', 'speed'\."):
+                r"Choices are 'id', 'make', 'make_id', 'model', 'passengers', 'sedan', 'speed'\."):
             self.mock_set.filter(bad_field='bogus')
 
     def test_query_exclude(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
-envlist = py27, py33, py34, py35
+envlist =
+    py{27,33,34,35}-dj18
+    py{27,34,35}-dj{19,110}
+# See https://docs.djangoproject.com/en/1.10/faq/install/#what-python-version-can-i-use-with-django
 
 [pytest]
 norecursedirs = examples
@@ -7,7 +10,11 @@ flake8-ignore = *.py F403 F405
 flake8-max-line-length = 120
 
 [testenv]
-deps = -rrequirements/requirements-testing.txt
+deps =
+    -rrequirements/requirements-testing.txt
+    dj18: Django==1.8.17
+    dj19: Django==1.9.12
+    dj110: Django==1.10.5
 commands =
     py.test django_mock_queries/ tests/ --cov-report term-missing --cov=django_mock_queries --flake8
     python -c "import subprocess; subprocess.check_call(['./manage.py', 'test', '--settings=users.settings_mocked'], cwd='examples/users')"


### PR DESCRIPTION
Here's a slightly late Christmas gift. This is the feature we've been stabilizing in our project, and I think it's ready now. It's a big change, so just ask if you want me to make some changes to make it more compatible with your project.
I added Django 1.9 and 1.10 to the tox environments, because mocked_relations is affected by changes in the Django plumbing.
One of the serializer tests is broken by a change in Django 1.10, so I marked it as skipped for now. I'm not sure how to fix it, because I don't really understand what it's testing. If you can explain the test to me, I might be able to help adapt it to Django 1.10.
Here's the Django [change] that broke the serializer test:

>If you delete a field from a model instance, accessing it again reloads the value from the database:
>```
>>> obj = MyModel.objects.first()
>>> del obj.field
>>> obj.field  # Loads the field from the database
>```
>Changed in Django 1.10:
>In older versions, accessing a deleted field raised AttributeError instead of reloading it.

[change]: https://docs.djangoproject.com/en/1.10/ref/models/instances/#refreshing-objects-from-database