### PR TITLE
_meta, values(), values_list()

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -215,7 +215,7 @@ def MockSet(*initial_items, **kwargs):
             for item in items:
                 a = list()
                 for field in fields:
-                    if field not in item._meta._forward_fields_map.keys():
+                    if field not in [f.attname for f in item._meta.concrete_fields]:
                         raise AttributeError('Mocked model %s has no field %s' % (item, field))
                     a.append(getattr(item, field))
                 if flat:
@@ -232,13 +232,13 @@ def MockSet(*initial_items, **kwargs):
         for item in items:
             if len(fields) == 0:
                 item_dict = {}
-                for field in item._meta._forward_fields_map.keys():
+                for field in [f.attname for f in item._meta.concrete_fields]:
                     item_dict[field] = getattr(item, field)
                 result.append(item_dict)
             else:
                 item_dict = {}
                 for field in fields:
-                    if field not in item._meta._forward_fields_map.keys():
+                    if field not in [f.attname for f in item._meta.concrete_fields]:
                         raise AttributeError('Mocked model %s has no field %s' % (item, field))
                     item_dict[field] = getattr(item, field)
                 result.append(item_dict)
@@ -253,7 +253,9 @@ def MockSet(*initial_items, **kwargs):
 def MockModel(cls=None, mock_name=None, spec_set=None, **attrs):
     mock_attrs = dict(spec=cls, name=mock_name, spec_set=spec_set)
 
-    _meta = type('_meta', (object,), dict(_forward_fields_map=attrs, fields_map={}, parents={}))
+    _meta = type('_meta', (object,), dict(
+        _forward_fields_map={}, fields_map={}, parents={},
+        concrete_fields=[type('concrete_field', (object,), dict(attname=x)) for x in attrs.keys()]))
 
     mock_model = MagicMock(**mock_attrs)
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -519,7 +519,7 @@ class TestQuery(TestCase):
         qs = MockSet(MockModel(foo=1), MockModel(foo=2))
         self.assertRaises(TypeError, qs.values_list, 'foo', 'bar', flat=True)
 
-    def test_query_values_list_raises_attribute_error_when_field_is_not_in_forward_fields_map(self):
+    def test_query_values_list_raises_attribute_error_when_field_is_not_in_meta_concrete_fields(self):
         qs = MockSet(MockModel(foo=1), MockModel(foo=2))
         self.assertRaises(AttributeError, qs.values_list, 'bar')
 
@@ -543,7 +543,7 @@ class TestQuery(TestCase):
         assert results_with_fields[0] == (1, 3)
         assert results_with_fields[1] == (2, 4)
 
-    def test_query_values_raises_attribute_error_when_field_is_not_in_forward_fields_map(self):
+    def test_query_values_raises_attribute_error_when_field_is_not_in_meta_concrete_fields(self):
         qs = MockSet(MockModel(foo=1), MockModel(foo=2))
         self.assertRaises(AttributeError, qs.values, 'bar')
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -18,35 +18,6 @@ class TestQuery(TestCase):
         items = [1, 2, 3]
         assert MockSet(*items).count() == len(items)
 
-    def test_query_project_returns_whole_item_by_index(self):
-        item_1 = MockModel(foo=1)
-        item_2 = MockModel(foo=2)
-
-        qs = MockSet(item_1, item_2)
-        assert qs.project(1) == item_2
-
-    def test_query_project_returns_item_flat_attribute(self):
-        item_1 = MockModel(foo=1)
-        item_2 = MockModel(foo=2)
-
-        qs = MockSet(item_1, item_2)
-        qs.flat = True
-        qs.projection = ['foo']
-
-        assert qs.project(1) == item_2.foo
-
-    def test_query_project_returns_item_specified_attributes_tuple(self):
-        item_1 = MockModel(foo=1, bar='a')
-        item_2 = MockModel(foo=2, bar='b')
-
-        qs = MockSet(item_1, item_2)
-        qs.flat = False
-        qs.projection = ['foo', 'bar']
-
-        attrs = qs.project(1)
-        assert attrs[0] == item_2.foo
-        assert attrs[1] == item_2.bar
-
     def test_query_adds_items_to_set(self):
         items = [1, 2, 3]
         self.mock_set.add(*items)
@@ -548,13 +519,51 @@ class TestQuery(TestCase):
         qs = MockSet(MockModel(foo=1), MockModel(foo=2))
         self.assertRaises(TypeError, qs.values_list, 'foo', 'bar', flat=True)
 
-    def test_query_values_list_returns_qs_clone_with_flat_and_projection_fields_set(self):
-        item_1 = MockModel(foo=1)
-        item_2 = MockModel(foo=2)
+    def test_query_values_list_raises_attribute_error_when_field_is_not_in_forward_fields_map(self):
+        qs = MockSet(MockModel(foo=1), MockModel(foo=2))
+        self.assertRaises(AttributeError, qs.values_list, 'bar')
+
+    def test_query_values_list_raises_not_implemented_if_no_fields_specified(self):
+        qs = MockSet(MockModel(foo=1), MockModel(foo=2))
+        self.assertRaises(NotImplementedError, qs.values_list)
+
+    def test_query_values_list(self):
+        item_1 = MockModel(foo=1, bar=3)
+        item_2 = MockModel(foo=2, bar=4)
 
         qs = MockSet(item_1, item_2)
-        projection = ('foo',)
-        obj = qs.values_list(*projection, flat=True)
+        results_flat = qs.values_list('foo', flat=True)
+        results_single_fields = qs.values_list('foo')
+        results_with_fields = qs.values_list('foo', 'bar')
 
-        assert obj.flat is True
-        assert obj.projection == projection
+        assert results_flat[0] == 1
+        assert results_flat[1] == 2
+        assert results_single_fields[0] == (1,)
+        assert results_single_fields[1] == (2,)
+        assert results_with_fields[0] == (1, 3)
+        assert results_with_fields[1] == (2, 4)
+
+    def test_query_values_raises_attribute_error_when_field_is_not_in_forward_fields_map(self):
+        qs = MockSet(MockModel(foo=1), MockModel(foo=2))
+        self.assertRaises(AttributeError, qs.values, 'bar')
+
+    def test_query_values(self):
+        item_1 = MockModel(foo=1, bar=3, foobar=5)
+        item_2 = MockModel(foo=2, bar=4, foobar=6)
+
+        qs = MockSet(item_1, item_2)
+
+        results_all = qs.values()
+        results_with_fields = qs.values('foo', 'bar')
+
+        assert results_all[0]['foo'] == 1
+        assert results_all[0]['bar'] == 3
+        assert results_all[0]['foobar'] == 5
+        assert results_all[1]['foo'] == 2
+        assert results_all[1]['bar'] == 4
+        assert results_all[1]['foobar'] == 6
+
+        assert results_with_fields[0]['foo'] == 1
+        assert results_with_fields[0]['bar'] == 3
+        assert results_with_fields[1]['foo'] == 2
+        assert results_with_fields[1]['bar'] == 4

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -60,8 +60,14 @@ class TestUtils(TestCase):
         assert value == default_value
         assert comparison is None
 
-    def test_get_attribute_raises_exception_when_spec_set_is_true(self):
-        obj = query.MockModel(spec_set=True, foo='foo_value')
+    def test_get_attribute_returns_value_when_spec_set_is_true(self):
+        obj = query.MockModel(spec_set=True, foo='foo')
+        value, comparison = utils.get_attribute(obj, 'foo')
+        assert value == 'foo'
+        assert comparison is None
+
+    def test_getattr_builtin_raises_exception_when_spec_set_is_true(self):
+        obj = query.MockModel(spec_set=True, foo='foo')
         assert getattr(obj, 'bar', None) is None
         with self.assertRaises(AttributeError):
             getattr(obj, 'bar')


### PR DESCRIPTION
Happy new year and thanks for your feedback! After reading your comments on PR #26 and PR #27 I decided to change MockModel() function so mocked model will now have _meta attribute. I merged changes from PR #26 and #27 and added some changes so now _meta._forward_fields_map contains kwargs from MockSet() function calls.

P. S. I closed #29 because of messed commit.