### PR TITLE
MockSetModel, _meta abstraction, get_or_create with defaults!

### DIFF
--- a/django_mock_queries/mocks.py
+++ b/django_mock_queries/mocks.py
@@ -11,7 +11,7 @@ from functools import partial
 from itertools import chain
 from mock import Mock, MagicMock, patch, PropertyMock
 
-from .query import MockSet
+from .query import MockSet, MockSetModel
 
 
 def monkey_patch_test_db(disabled_features=None):
@@ -213,10 +213,12 @@ def mocked_relations(*models):
             Mock,
             name=model_name + '.save')))
         if hasattr(model, 'objects'):
+            field_names = [f.attname for f in model._meta.concrete_fields]
             patchers.append(patch_object(model, 'objects', new_callable=partial(
                 MockSet,
                 mock_name=model_name + '.objects',
-                cls=model)))
+                cls=model,
+                model=MockSetModel(*field_names))))
         for related_object in chain(model._meta.related_objects,
                                     model._meta.many_to_many):
             name = related_object.name

--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -32,6 +32,7 @@ def MockSet(*initial_items, **kwargs):
     ])
     mock_set.cls = clone.cls if clone else kwargs.get('cls', empty_func)
     mock_set.count = MagicMock(side_effect=lambda: len(items))
+    mock_set.model = clone.model if clone else kwargs.get('model', None)
 
     def add(*model):
         items.extend(model)
@@ -173,6 +174,15 @@ def MockSet(*initial_items, **kwargs):
     mock_set.__iter__ = MagicMock(side_effect=__iter__)
 
     def create(**attrs):
+        if mock_set.model:
+            # Make sure that every key in attrs is in concrete_fields
+            for k in attrs.keys():
+                if k not in [f.attname for f in mock_set.model._meta.concrete_fields]:
+                    raise ValueError('MockSet model has no field {}'.format(k))
+            # Fill concrete fields that are not specified in attrs with 'None'
+            for field in mock_set.model._meta.concrete_fields:
+                if field.attname not in attrs.keys():
+                    attrs[field.attname] = None
         obj = mock_set.cls(**attrs)
         if not obj:
             raise ModelNotSpecified()
@@ -193,8 +203,13 @@ def MockSet(*initial_items, **kwargs):
 
     mock_set.get = MagicMock(side_effect=get)
 
-    def get_or_create(**attrs):
-        results = filter(**attrs)
+    def get_or_create(defaults=None, **attrs):
+        if defaults is not None and mock_set.model is None:
+            raise ValueError('get_or_create() can be called only when MockSet has model attribute')
+        defaults = defaults or {}
+        lookup = attrs.copy()
+        attrs.update(defaults)
+        results = filter(**lookup)
         if not results.exists():
             return create(**attrs), True
         elif results.count() > 1:
@@ -256,11 +271,8 @@ def MockSet(*initial_items, **kwargs):
 
 def MockModel(cls=None, mock_name=None, spec_set=None, **attrs):
     mock_attrs = dict(spec=cls, name=mock_name, spec_set=spec_set)
-
-    _meta = type('_meta', (object,), dict(
-        _forward_fields_map={}, fields_map={}, parents={},
-        concrete_fields=[type('concrete_field', (object,), dict(attname=x)) for x in attrs.keys()]))
-
+    fields = [x for x in attrs.keys()]
+    _meta = MockMeta(*fields)
     mock_model = MagicMock(**mock_attrs)
 
     if mock_name:
@@ -272,6 +284,33 @@ def MockModel(cls=None, mock_name=None, spec_set=None, **attrs):
     setattr(type(mock_model), '_meta', PropertyMock(return_value=_meta))
 
     return mock_model
+
+
+def MockSetModel(*fields):
+    if len(fields) == 0:
+        raise ValueError('MockSetModel is called without fields specified')
+    _meta = MockMeta(*fields)
+    mock_model = MagicMock(spec_set=True)
+    setattr(type(mock_model), '_meta', PropertyMock(return_value=_meta))
+    return mock_model
+
+
+class MockMeta(object):
+    def __init__(self, *fields):
+        for key in ('_forward_fields_map', 'parents', 'fields_map'):
+            self.__dict__[key] = {}
+        for key in ('local_concrete_fields', 'concrete_fields', 'fields'):
+            self.__dict__[key] = []
+
+        for field in fields:
+            for key in ('local_concrete_fields', 'concrete_fields', 'fields'):
+                self.__dict__[key].append(MockField(field))
+
+
+class MockField(object):
+    def __init__(self, field):
+        for key in ('name', 'attname'):
+            self.__dict__[key] = field
 
 
 def empty_func(*args, **kwargs):

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -339,6 +339,14 @@ class MockedRelationsTest(TestCase):
         with self.assertRaises(Manufacturer.DoesNotExist):
             Manufacturer.objects.get(name='sam')
 
+    @mocked_relations(Car)
+    def test_creation_of_mocksetmodel_with_concrete_fields(self):
+        mocked_fields = [f.attname for f in Car.objects.model._meta.concrete_fields]
+        assert 'make_id' in mocked_fields
+        assert 'id' in mocked_fields
+        assert 'speed' in mocked_fields
+        assert 'model' in mocked_fields
+
 
 class TestMockers(TestCase):
     class CarModelMocker(ModelMocker):


### PR DESCRIPTION
I've decided to add 'model' property to MockSet, which in fact is an instance of a new MockSetModel class, which consists of MockSetMeta instance, which attributes are filled with MockField instances.
This is done to abstract _meta and _meta attributes so we can tweak with it in the future.
I used \_\_dict\_\_ in \_\_init\_\_ because I think that at some point we'll have to restrict access to some attributes of MockMeta() instances by overloading the \_\_setattr\_\_ method like this:
```python
def__setattr__(...):
    raise AttributeError(...)
```
If a MockSet has a 'model' property, we can call get_or_create() with defaults, which in fact calls create(); unspecified fields with be set to None if all other attributes are correct and do not raise errors.

Patching model with 'mocked_relations' decorator now also performs an addition of 'model' attribute to MockSet, picking original model's concrete fields.

I also propose the renamings of MockModel and MockSetModel to MockInstance and MockModel respectively in the future.

I'm having doubts about this approach, though. Any ideas about better approach to "link" MockSet, MockModel and mocked instances?