### PR TITLE
Fix one-to-many field lookup to use model name

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -115,7 +115,7 @@ def MockSet(*initial_items, **kwargs):
             expr_result = None
 
             for x in items:
-                val = get_attribute(x, expr.source_expressions[0].name, related_set_singular=True)[0]
+                val = get_attribute(x, expr.source_expressions[0].name)[0]
                 if val is None:
                     continue
                 values.extend(val if is_list_like_iter(val) else [val])
@@ -246,7 +246,7 @@ def MockSet(*initial_items, **kwargs):
             result_count = 1
 
             for field in sorted(field_names, key=lambda k: k.count('__')):
-                value = get_attribute(item, field, related_set_singular=True)[0]
+                value = get_attribute(item, field)[0]
 
                 if is_list_like_iter(value):
                     value = flatten_list(value)

--- a/django_mock_queries/utils.py
+++ b/django_mock_queries/utils.py
@@ -21,7 +21,7 @@ def find_field_names(obj, **kwargs):
         name = field.get_accessor_name()
         model_name = field.related_model._meta.model_name.lower()
 
-        if kwargs.get('related_set_singular', False) and name[-4:] == '_set':
+        if name[-4:] == '_set':
             return {model_name: name}
         else:
             return {name: name}

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -353,7 +353,7 @@ class MockedRelationsTest(TestCase):
         manufacturer.car_set.add(car)
         Manufacturer.objects.add(manufacturer)
 
-        car_manufacturers = Manufacturer.objects.filter(car_set=car)
+        car_manufacturers = Manufacturer.objects.filter(car=car)
 
         self.assertEqual([manufacturer], list(car_manufacturers))
 


### PR DESCRIPTION
This only holds when foreign key related name is not set.