### PR TITLE
Support filtering on a values list subquery.

### DIFF
--- a/django_mock_queries/utils.py
+++ b/django_mock_queries/utils.py
@@ -148,7 +148,10 @@ def extract(obj, comparison):
 
 
 def convert_to_pks(query):
-    return [item.pk for item in query]
+    try:
+        return [item.pk for item in query]
+    except AttributeError:
+        return query  # Didn't have pk's, keep original items
 
 
 def is_match_in_children(comparison, first, second):

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,6 +2,7 @@ pytest==3.0.3
 pytest-cov==2.4.0
 pytest-flake8==0.7
 pytest-django==3.1.2
+flake8==3.4.1
 coverage==3.7.1
 tox==2.1.1
 virtualenv==13.1.2

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -149,6 +149,19 @@ class TestQuery(TestCase):
 
         self.assertEqual(list(old_cars), list(matches))
 
+    def test_convert_values_list_to_pks(self):
+        car1 = Car(id=101)
+        car2 = Car(id=102)
+        car3 = Car(id=103)
+
+        old_cars = MockSet(car1, car2)
+        old_car_pks = old_cars.values_list("pk", flat=True)
+        all_cars = MockSet(car1, car2, car3)
+
+        matches = all_cars.filter(pk__in=old_car_pks)
+
+        self.assertEqual(list(old_cars), list(matches))
+
     def test_query_filters_model_objects_by_bad_field(self):
         item_1 = Car(speed=1)
         item_2 = Sedan(speed=2)


### PR DESCRIPTION
It looks like I removed an exception handler that I shouldn't have back in [February]. This pull request puts the exception handler back, along with a test that shows when it's needed.

Here's a snippet that shows how the real Django query set supports filtering by a values list:

    # Tested with Django 1.9.2
    import sys
    
    import django
    from django.apps import apps
    from django.apps.config import AppConfig
    from django.conf import settings
    from django.db import connections, models, DEFAULT_DB_ALIAS
    from django.db.models.base import ModelBase
    
    NAME = 'udjango'
    
    
    def main():
        setup()
    
        class Car(models.Model):
            model = models.CharField(max_length=25, blank=True, null=True)
            year = models.IntegerField()
    
        syncdb(Car)
    
        Car.objects.create(model='Gremlin', year=1970)
        Car.objects.create(model='Pinto', year=1971)
        Car.objects.create(model='Smart Car', year=2000)
    
        old_cars = Car.objects.filter(year__lt=1990)
        old_car_pks = old_cars.values_list("pk", flat=True)
    
        matches = Car.objects.filter(pk__in=old_car_pks)
    
        assert list(old_cars) == list(matches)
    
    
    def setup():
        DB_FILE = NAME + '.db'
        with open(DB_FILE, 'w'):
            pass  # wipe the database
        settings.configure(
            DEBUG=True,
            DATABASES={
                DEFAULT_DB_ALIAS: {
                    'ENGINE': 'django.db.backends.sqlite3',
                    'NAME': DB_FILE}},
            LOGGING={'version': 1,
                     'disable_existing_loggers': False,
                     'formatters': {
                        'debug': {
                            'format': '%(asctime)s[%(levelname)s]'
                                      '%(name)s.%(funcName)s(): %(message)s',
                            'datefmt': '%Y-%m-%d %H:%M:%S'}},
                     'handlers': {
                        'console': {
                            'level': 'DEBUG',
                            'class': 'logging.StreamHandler',
                            'formatter': 'debug'}},
                     'root': {
                        'handlers': ['console'],
                        'level': 'WARN'},
                     'loggers': {
                        "django.db": {"level": "WARN"}}})
        app_config = AppConfig(NAME, sys.modules['__main__'])
        apps.populate([app_config])
        django.setup()
        original_new_func = ModelBase.__new__
    
        @staticmethod
        def patched_new(cls, name, bases, attrs):
            if 'Meta' not in attrs:
                class Meta:
                    app_label = NAME
                attrs['Meta'] = Meta
            return original_new_func(cls, name, bases, attrs)
        ModelBase.__new__ = patched_new
    
    
    def syncdb(model):
        """ Standard syncdb expects models to be in reliable locations.
    
        Based on https://github.com/django/django/blob/1.9.3
        /django/core/management/commands/migrate.py#L285
        """
        connection = connections[DEFAULT_DB_ALIAS]
        with connection.schema_editor() as editor:
            editor.create_model(model)
    
    main()

[February]: https://github.com/stphivos/django-mock-queries/pull/34/commits/9a096cbe16264370530ef62a307c0e9a7b5444ad#diff-ea23edd97987c37ccaf53808d0bfb005