### PR TITLE
Keep the previous name for decorated methods, functions and classes

### DIFF
--- a/django_mock_queries/mocks.py
+++ b/django_mock_queries/mocks.py
@@ -257,8 +257,12 @@ class PatcherChain(object):
 
     def __call__(self, func):
         if isinstance(func, type):
-            return self.decorate_class(func)
-        return self.decorate_callable(func)
+            decorated = self.decorate_class(func)
+        decorated = self.decorate_callable(func)
+        # keep the previous class/function name
+        decorated.__name__ = func.__name__
+        
+        return decorated
 
     def decorate_class(self, cls):
         for attr in dir(cls):
@@ -338,6 +342,8 @@ class Mocker(object):
         def decorated(*args, **kwargs):
             with self:
                 return func(*((args[0], self) + args[1:]), **kwargs)
+        # keep the previous method name
+        decorated.__name__ = func.__name__
 
         return decorated
 

--- a/django_mock_queries/mocks.py
+++ b/django_mock_queries/mocks.py
@@ -258,7 +258,8 @@ class PatcherChain(object):
     def __call__(self, func):
         if isinstance(func, type):
             decorated = self.decorate_class(func)
-        decorated = self.decorate_callable(func)
+        else:
+            decorated = self.decorate_callable(func)
         # keep the previous class/function name
         decorated.__name__ = func.__name__
         

--- a/django_mock_queries/mocks.py
+++ b/django_mock_queries/mocks.py
@@ -262,7 +262,7 @@ class PatcherChain(object):
             decorated = self.decorate_callable(func)
         # keep the previous class/function name
         decorated.__name__ = func.__name__
-        
+
         return decorated
 
     def decorate_class(self, cls):


### PR DESCRIPTION
I'm using a Nose tool for running my tests in Django.
It looks for test methods and classes with 'test' word in name.

Without this change, django_mock_queries lib hides a real method/function/class name.