### PR TITLE
Omit call to save in MockSet.create

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -245,7 +245,6 @@ def MockSet(*initial_items, **kwargs):
         #         attrs[field] = None
 
         obj = mock_set.model(**attrs)
-        obj.save(force_insert=True, using=MagicMock())
         add(obj)
 
         return obj

--- a/examples/users/analytics/tests.py
+++ b/examples/users/analytics/tests.py
@@ -69,9 +69,6 @@ class TestMockedApi(TestCase):
         for k, v in attrs.items():
             assert getattr(user, k) == v
 
-        # noinspection PyUnresolvedReferences
-        assert User.save.call_count == 1
-
     def test_api_today_visitors_counts_todays_logins(self):
         past_visitors = [
             MockModel(last_login=(date.today() - timedelta(days=1))),

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -386,6 +386,11 @@ class TestMockers(TestCase):
             obj.save()
             self.assertEqual(Car.objects.get(pk=obj.id), obj)
 
+    def test_model_mocker_generic_with_objects_create(self):
+        with ModelMocker(Car):
+            obj = Car.objects.create(speed=10)
+            self.assertEqual(Car.objects.get(pk=obj.id), obj)
+
     def test_model_mocker_with_custom_method(self):
         with self.CarModelMocker(Car, 'validate_price') as mocker:
             obj = Car()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,6 +1,6 @@
 import datetime
 
-from mock import MagicMock, ANY
+from mock import MagicMock
 from unittest import TestCase
 
 from django.core.exceptions import FieldError
@@ -568,7 +568,7 @@ class TestQuery(TestCase):
         qs = MockSet(model=create_model('foo', 'bar', 'none'))
         attrs = dict(foo=1, bar='a')
         obj = qs.create(**attrs)
-        obj.save.assert_called_once_with(force_insert=True, using=ANY)
+
         assert obj in [x for x in qs]
         assert hasattr(obj, 'foo') and obj.foo == 1
         assert hasattr(obj, 'bar') and obj.bar == 'a'


### PR DESCRIPTION
* Avoids the need to patch model save when using `MockSet.create`
* Fixes using `Model.objects.create` within `ModelMocker` context which created objects twice