### PR TITLE
Attempt to improve performance of MockSet by reducing the use of MagicMock.

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -189,7 +189,11 @@ class MockSet(MagicMock):
                 "arguments or 'get_latest_by' in the model's Meta."
             )
 
-        results = sorted(self.items, key=lambda obj: tuple(get_attribute(obj, key) for key in order_fields), reverse=reverse)
+        results = sorted(
+            self.items,
+            key=lambda obj: tuple(get_attribute(obj, key) for key in order_fields),
+            reverse=reverse,
+        )
         if len(results) == 0:
             self.raise_does_not_exist()
 

--- a/django_mock_queries/utils.py
+++ b/django_mock_queries/utils.py
@@ -97,10 +97,10 @@ def get_attribute(obj, attr, default=None, **kwargs):
 
 
 def is_match(first, second, comparison=None):
-    if isinstance(first, django_mock_queries.query.MockBase):
+    if isinstance(first, django_mock_queries.query.MockSet):
         return is_match_in_children(comparison, first, second)
     if (isinstance(first, (int, str)) and
-            isinstance(second, django_mock_queries.query.MockBase)):
+            isinstance(second, django_mock_queries.query.MockSet)):
         second = convert_to_pks(second)
     if (isinstance(first, date) or isinstance(first, datetime)) \
             and isinstance(comparison, tuple) and len(comparison) == 2:
@@ -218,7 +218,7 @@ def validate_date_or_datetime(value, comparison):
 def is_list_like_iter(obj):
     if isinstance(obj, django_mock_queries.query.MockModel):
         return False
-    elif isinstance(obj, django_mock_queries.query.MockBase):
+    elif isinstance(obj, django_mock_queries.query.MockSet):
         return True
     elif isinstance(obj, Mock):
         return False


### PR DESCRIPTION
First, Sorry for the long diff. Second, note this is a backwards incompatible change for any users of django-mock-queries that may rely on the mocked methods been MagicMocks (e.g. calling mock_set.filter.assert_called_once_with in tests).

Reason behind this change: When profiling speed for some tests that were using django-mock-queries I noticed most of the time was going into the creation of magic mocks. Changing MockSet from a function to a class and not creating magic mocks for every function we are overriding speeds things up quite a bit. In my local each py.test django_mock_queries/ tests/ was taking > 4s before and now it is ~ 1.3s However in travis-ci.org I am not seen improvements maybe host is shared and other things running may slow down the test run. Please check in your local.
