### PR TITLE
Fix: Empty querysets should be evaluated to False when converted to boolean

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -44,6 +44,7 @@ class MockSet(MagicMock):
         self.__len__ = lambda s: len(s.items)
         self.__iter__ = lambda s: iter(s.items)
         self.__getitem__ = lambda s, k: self.items[k]
+        self.__bool__ = lambda s: len(s.items) > 0
 
     def _return_self(self, *_, **__):
         return self

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1211,3 +1211,7 @@ class TestQuery(TestCase):
         assert len(result) == 2
         assert result[0] == datetime.datetime(2017, 1, 10, 1, 2, 9)
         assert result[1] == datetime.datetime(2017, 1, 10, 1, 2, 3)
+
+    def test_empty_queryset_bool_converts_to_false(self):
+        qs = MockSet()
+        assert not bool(qs)


### PR DESCRIPTION
# What problem is being solved
In Django, when you have an empty queryset and the code evaluates it as a boolean, the expected result is `False`.
As `MockSet` is a subclass of MagicMock, this automatically consider `__bool__` as a mocked method, being always evaluated to `True` regardless of the amount of items on that given queryset.


# How is this being solved
Implemented the `__bool__` method as a lambda expression returning a boolean based on the amount of items on the given MockSet instance.