### PR TITLE
Fix MockSet empty querysets evaluated to False when converted to bool in py27

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -44,7 +44,7 @@ class MockSet(MagicMock):
         self.__len__ = lambda s: len(s.items)
         self.__iter__ = lambda s: iter(s.items)
         self.__getitem__ = lambda s, k: self.items[k]
-        self.__bool__ = lambda s: len(s.items) > 0
+        self.__bool__ = self.__nonzero__ = lambda s: len(s.items) > 0
 
     def _return_self(self, *_, **__):
         return self

--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -44,6 +44,7 @@ class MockSet(MagicMock):
         self.__len__ = lambda s: len(s.items)
         self.__iter__ = lambda s: iter(s.items)
         self.__getitem__ = lambda s, k: self.items[k]
+        self.__bool__ = lambda s: len(s.items) > 0
 
     def _return_self(self, *_, **__):
         return self

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1211,3 +1211,7 @@ class TestQuery(TestCase):
         assert len(result) == 2
         assert result[0] == datetime.datetime(2017, 1, 10, 1, 2, 9)
         assert result[1] == datetime.datetime(2017, 1, 10, 1, 2, 3)
+
+    def test_empty_queryset_bool_converts_to_false(self):
+        qs = MockSet()
+        assert not bool(qs)


### PR DESCRIPTION
Amends PR https://github.com/stphivos/django-mock-queries/pull/86