### PR TITLE
Add support for Django 2.2 and Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ matrix:
       - TOX_ENV=py27-dj19-drf33
       - TOX_ENV=py27-dj110-drf33
       - TOX_ENV=py27-dj111-drf37
-    - python: 3.3
-      env:
-      - TOX_ENV=py33-dj18-drf33
     - python: 3.4
       env:
       - TOX_ENV=py34-dj18-drf33
@@ -29,11 +26,32 @@ matrix:
       - TOX_ENV=py35-dj111-drf37
       - TOX_ENV=py35-dj20-drf37
       - TOX_ENV=py35-dj21-drf37
+      - TOX_ENV=py35-dj22-drf37
+      - TOX_ENV=py35-dj111-drf39
+      - TOX_ENV=py35-dj20-drf39
+      - TOX_ENV=py35-dj21-drf39
+      - TOX_ENV=py35-dj22-drf39
     - python: 3.6
       env:
       - TOX_ENV=py36-dj111-drf37
       - TOX_ENV=py36-dj20-drf37
       - TOX_ENV=py36-dj21-drf37
+      - TOX_ENV=py36-dj22-drf37
+      - TOX_ENV=py36-dj111-drf39
+      - TOX_ENV=py36-dj20-drf39
+      - TOX_ENV=py36-dj21-drf39
+      - TOX_ENV=py36-dj22-drf39
+    - python: 3.7
+      env:
+      - TOX_ENV=py37-dj111-drf37
+      - TOX_ENV=py37-dj20-drf37
+      - TOX_ENV=py37-dj21-drf37
+      - TOX_ENV=py37-dj22-drf37
+      - TOX_ENV=py37-dj111-drf39
+      - TOX_ENV=py37-dj20-drf39
+      - TOX_ENV=py37-dj21-drf39
+      - TOX_ENV=py37-dj22-drf39
+
 
 install:
   - travis_retry pip install "virtualenv<14.0.0" "tox>=1.9" "coverage<4" "setuptools<40.0.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial   # required for Python >= 3.7
 language: python
 
 sudo: false

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,3 +1,3 @@
 mock
 model_mommy>=1.5.1
-Django>=1.8.17,<2.1.99
+Django>=1.8.17,<2.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
-pytest==3.0.3
+pytest==3.10.1
 pytest-cov==2.4.0
 pytest-flake8==0.7
 pytest-django==3.1.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,3 +9,4 @@ virtualenv==13.1.2
 pypandoc==1.4
 setuptools==39.2.0
 twine==1.11.0
+more-itertools<6.0.0; python_version < '3'

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,16 @@
 [tox]
 # See https://docs.djangoproject.com/en/2.0/faq/install/#what-python-version-can-i-use-with-django
 envlist =
-    py{27,33,34,35}-dj18-drf33
+    py{27,34,35}-dj18-drf33
     py{27,34,35}-dj{19,110}-drf33
-    py{27,34,35,36}-dj{111}-drf37
-    py{34,35,36}-dj{20}-drf37
-    py{35,36}-dj{21}-drf37
+    py{27,34,35,36,37}-dj{111}-drf37
+    py{34,35,36,37}-dj{20}-drf37
+    py{35,36,37}-dj{21}-drf37
+    py{35,36,37}-dj{22}-drf37
+    py{27,34,35,36,37}-dj{111}-drf39
+    py{34,35,36,37}-dj{20}-drf39
+    py{35,36,37}-dj{21}-drf39
+    py{35,36,37}-dj{22}-drf39
 
 [pytest]
 norecursedirs = examples
@@ -21,8 +26,10 @@ deps =
     dj111: Django==1.11.6
     dj20: Django==2.0.2
     dj21: Django==2.1
+    dj22: Django==2.2
     drf33: djangorestframework==3.3.2
     drf37: djangorestframework==3.7.7
+    drf39: djangorestframework==3.9.2
 
 commands =
     py.test django_mock_queries/ tests/ --cov-report term-missing --cov=django_mock_queries --flake8


### PR DESCRIPTION
The main goal here was to add support for Django 2.2 as a dependency, as the current requirements.txt prevents our apps from upgrading to the latest version.

While I was at it, I decided to add tests for the latest versions of Python (3.7) and DRF (3.9.2).

I also dropped support for Python 3.3 because Travis doesn't appear to support it anymore.

Long term, I suggest considering the removal of a max version of Django in the setup.py because of the aforementioned restrictions it puts on the users of this library. Regardless, I stuck with the existing paradigm in this PR to get things moving forward.

Also, if this PR is sufficient, please consider pushing a new 2.1.2 release to pypi for the community. 

Thanks!