### PR TITLE
Extend get_field_values to work for date/datetime objects

### DIFF
--- a/django_mock_queries/utils.py
+++ b/django_mock_queries/utils.py
@@ -93,6 +93,8 @@ def get_field_value(obj, field_name, default=None):
         return obj.get(field_name, default)
     elif is_list_like_iter(obj):
         return [get_attribute(x, field_name, default)[0] for x in obj]
+    elif is_like_date_or_datetime(obj):
+        return obj
     else:
         return getattr(obj, field_name, default)
 
@@ -243,6 +245,10 @@ def is_list_like_iter(obj):
         return False
 
     return hasattr(obj, '__iter__') and not isinstance(obj, str)
+
+
+def is_like_date_or_datetime(obj):
+    return type(obj) in [date, datetime]
 
 
 def flatten_list(source):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -323,3 +323,30 @@ class TestUtils(TestCase):
         results = utils.matches(*source, foo__range=(1, 2))
         assert source[0] in results
         assert source[1] not in results
+
+    def test_is_like_date_or_datetime_for_datetime_obj(self):
+        result = utils.is_like_date_or_datetime(date(2019, 1, 1))
+        assert result is True
+
+    def test_is_like_date_or_datetime_for_date_obj(self):
+        result = utils.is_like_date_or_datetime(datetime(2019, 1, 1))
+        assert result is True
+
+    def test_is_like_date_or_datetime_for_non_date_or_datetime_obj(self):
+        result = utils.is_like_date_or_datetime('non_datetime_obj')
+        assert result is False
+
+    def test_get_field_value_returns_dict_value(self):
+        dict_obj = {'key': 45}
+        result = utils.get_field_value(dict_obj, 'key')
+        assert result == 45
+
+    def test_get_field_value_returns_datetime_obj(self):
+        datetime_obj = datetime(2019, 1, 2)
+        result = utils.get_field_value(datetime_obj, 'date')
+        assert result == datetime_obj
+
+    def test_get_field_value_returns_date_obj(self):
+        date_obj = date(2019, 1, 2)
+        result = utils.get_field_value(date_obj, 'date')
+        assert result == date_obj


### PR DESCRIPTION
When you have something like:

```py
def get_distinct_date_fields():
     list(
       ModelA
       .objects
       .filter(
           date_field__gte=date(2019, 1, 1)
       )
       .values_list('date_field', flat=True)
       .order_by('date_field')
       .distinct()
     )
```

and then you try and mock the above by going:

```py
def test(self, mocker):
     qs = MockSet(
            ModelA(date_field=date(2019, 2, 2)),
            ModelA(date_field=date(2019, 3, 2)),
     )
     manager_mock = mocker.patch.object(ModelA, 'objects')
     manager_mock.filter.return_value = qs
     assert get_distinct_date_fields() == [date(2019, 2, 2), date(2019, 3, 2)]
```

*I haven't ran the above code -- it's just pseudocode matching what I'm dealing in my own repo*

the `.distinct()` doesn't work properly since the `get_field_value` will return `None` for the date/datetime objects and the hash returned will be exactly the same. What ends up being returned is just one date value even though there should be two.

Thanks!