### PR TITLE
adding named values list

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -372,11 +372,14 @@ class MockSet(MagicMock):
         result = []
         item_values_dicts = list(self.values(*fields))
 
-        for values_dict in item_values_dicts:
-            result.append(self._item_values_list(values_dict, fields, flat))
         if named:
             Row = namedtuple('Row', fields)
-            result = [Row(*value) for value in result]
+            make_row = lambda values: Row(**values)
+        else:
+            make_row = lambda values: self._item_values_list(values, fields, flat)
+
+        for values_dict in item_values_dicts:
+            result.append(make_row(values_dict))
 
         return MockSet(*result, clone=self)
 

--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -372,16 +372,11 @@ class MockSet(MagicMock):
         result = []
         item_values_dicts = list(self.values(*fields))
 
-
-        Row = None
+        for values_dict in item_values_dicts:
+            result.append(self._item_values_list(values_dict, fields, flat))
         if named:
             Row = namedtuple('Row', fields)
-
-        for values_dict in item_values_dicts:
-            if named:
-                result.append(Row(**values_dict))
-            else:
-                result.append(self._item_values_list(values_dict, fields, flat))
+            result = [Row(*value) for value in result]
 
         return MockSet(*result, clone=self)
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -936,6 +936,22 @@ class TestQuery(TestCase):
         assert results_with_fields[0] == (1, 3)
         assert results_with_fields[1] == (2, 4)
 
+    def test_query_values_list_raises_type_error_if_flat_and_named_are_true(self):
+        qs = MockSet(MockModel(foo=1), MockModel(foo=2))
+        self.assertRaises(TypeError, qs.values_list, flat=True, named=True)
+
+    def test_named_query_values_list(self):
+        item_1 = MockModel(foo=1, bar=3)
+        item_2 = MockModel(foo=2, bar=4)
+
+        qs = MockSet(item_1, item_2)
+        results_with_named_fields_fields = qs.values_list('foo', 'bar', named=True)
+        assert results_with_named_fields_fields[0].foo == 1
+        assert results_with_named_fields_fields[0].bar == 3
+        assert results_with_named_fields_fields[1].foo == 2
+        assert results_with_named_fields_fields[1].bar == 4
+
+
     def test_query_values_list_of_nested_field(self):
         with mocked_relations(Manufacturer, Car):
             make = Manufacturer(name='vw')


### PR DESCRIPTION
[values_list can be names in django](tests/test_query.py)
 When that argument is true each item in the query is a `namedtuple` instead of a tuple.

This PR alters `values_list` in the following ways:
• Allows usage of the `named` kwarg and implements the return of the namedtuple
• Raises `TypeError` if `flat` and `named` are used together
• Adds tests for this specific use cases