### PR TITLE
#119 - fix order_by random

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -152,12 +152,15 @@ class MockSet(MagicMock):
 
     def order_by(self, *fields):
         results = self.items
-        for field in reversed(fields):
-            is_reversed = field.startswith('-')
-            attr = field[1:] if is_reversed else field
-            results = sorted(results,
-                             key=lambda r: get_attribute(r, attr),
-                             reverse=is_reversed)
+        if fields == ('?',):
+            random.shuffle(results)
+        else:
+            for field in reversed(fields):
+                is_reversed = field.startswith('-')
+                attr = field[1:] if is_reversed else field
+                results = sorted(results,
+                                key=lambda r: get_attribute(r, attr),
+                                reverse=is_reversed)
         return MockSet(*results, clone=self)
 
     def distinct(self, *fields):

--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -1,4 +1,5 @@
 import datetime
+import random
 from collections import OrderedDict, namedtuple
 from mock import Mock, MagicMock, PropertyMock
 
@@ -152,15 +153,15 @@ class MockSet(MagicMock):
 
     def order_by(self, *fields):
         results = self.items
-        if fields == ('?',):
-            results = random.shuffle(results)
-        else:
-            for field in reversed(fields):
-                is_reversed = field.startswith('-')
-                attr = field[1:] if is_reversed else field
-                results = sorted(results,
-                                key=lambda r: get_attribute(r, attr),
-                                reverse=is_reversed)
+        for field in reversed(fields):
+            if fields == '?':
+                random.shuffle(results)
+                break
+            is_reversed = field.startswith('-')
+            attr = field[1:] if is_reversed else field
+            results = sorted(results,
+                            key=lambda r: get_attribute(r, attr),
+                            reverse=is_reversed)
         return MockSet(*results, clone=self)
 
     def distinct(self, *fields):

--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -157,7 +157,7 @@ class MockSet(MagicMock):
     def order_by(self, *fields):
         results = self.items
         for field in reversed(fields):
-            if fields == '?':
+            if field == '?':
                 random.shuffle(results)
                 break
             is_reversed = field.startswith('-')

--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -153,7 +153,7 @@ class MockSet(MagicMock):
     def order_by(self, *fields):
         results = self.items
         if fields == ('?',):
-            random.shuffle(results)
+            results = random.shuffle(results)
         else:
             for field in reversed(fields):
                 is_reversed = field.startswith('-')

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -537,6 +537,16 @@ class TestQuery(TestCase):
 
         assert results == [item_1, item_2, item_3], results
 
+    def test_query_order_by_random(self):
+        qs = MockSet(
+            MockModel(mock_name='test1', email='test1@gmail.com'),
+            MockModel(mock_name='test2', email='test2@hotmail.com'),
+            MockModel(mock_name='test3', email='test3@gmail.com'),
+            MockModel(mock_name='test4', email='test4@hotmail.com'),
+        )
+
+        assert list(qs) != list(qs.order_by('?'))
+
     def test_query_distinct(self):
         item_1 = MockModel(foo=1, mock_name='item_1')
         item_2 = MockModel(foo=2, mock_name='item_2')


### PR DESCRIPTION
Fix for #119. Abilities to use order_by('?') to get random queryset.