### PR TITLE
Use unittest.mock when available instead of mock.

### DIFF
--- a/django_mock_queries/asserts.py
+++ b/django_mock_queries/asserts.py
@@ -1,4 +1,8 @@
-from mock import patch, Mock
+try:
+    from unittest.mock import patch, Mock
+except ImportError:
+    from mock import patch, Mock
+
 from model_bakery import baker
 
 from .constants import *

--- a/django_mock_queries/mocks.py
+++ b/django_mock_queries/mocks.py
@@ -9,7 +9,11 @@ from django.db.models import Model
 from django.db.utils import ConnectionHandler, NotSupportedError
 from functools import partial
 from itertools import chain
-from mock import Mock, MagicMock, patch, PropertyMock
+try:
+    from unittest.mock import Mock, MagicMock, patch, PropertyMock
+except ImportError:
+    from mock import Mock, MagicMock, patch, PropertyMock
+
 from types import MethodType
 
 from .constants import DjangoModelDeletionCollector, DjangoDbRouter

--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -1,6 +1,9 @@
 import datetime
 from collections import OrderedDict, namedtuple
-from mock import Mock, MagicMock, PropertyMock
+try:
+    from unittest.mock import Mock, MagicMock, PropertyMock
+except ImportError:
+    from mock import Mock, MagicMock, PropertyMock
 
 from .constants import *
 from .exceptions import *

--- a/django_mock_queries/utils.py
+++ b/django_mock_queries/utils.py
@@ -1,6 +1,9 @@
 from datetime import datetime, date
 from django.core.exceptions import FieldError
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from .constants import *
 from .exceptions import *

--- a/tests/test_asserts.py
+++ b/tests/test_asserts.py
@@ -1,4 +1,8 @@
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
 from model_bakery import baker
 from unittest import TestCase, skipIf
 

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -3,7 +3,11 @@ import django
 from django.db import connection
 from django.db.utils import NotSupportedError
 from django.db.backends.base.creation import BaseDatabaseCreation
-from mock import patch, MagicMock, PropertyMock
+try:
+    from unittest.mock import patch, MagicMock, PropertyMock
+except ImportError:
+    from mock import patch, MagicMock, PropertyMock
+
 from unittest import TestCase
 
 from django_mock_queries import mocks

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,6 +1,10 @@
 import datetime
 
-from mock import MagicMock
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
 from unittest import TestCase
 
 from django.core.exceptions import FieldError

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,9 @@
 from datetime import date, datetime
-from mock import patch, MagicMock
+try:
+    from unittest.mock import patch, MagicMock
+except ImportError:
+    from mock import patch, MagicMock
+
 from unittest import TestCase
 
 from django_mock_queries import utils, constants


### PR DESCRIPTION
To allow projects that make use of `unittest.mock` and has abandoned Python 2 forcefully removing the library `mock`, I changed the import to first try `unittest.mock` and failing it trying `mock` instead.