### PR TITLE
Build universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [metadata]
 description-file = README.md
+
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
In order to avoid users having to build a wheel when installing the package, this PR configures setup.py to build a universal wheel.