### PR TITLE
Fix MockSet too many positional arguments error in python 3.8

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -1,6 +1,7 @@
 import datetime
 import random
 from collections import OrderedDict, namedtuple
+from six import with_metaclass
 try:
     from unittest.mock import Mock, MagicMock, PropertyMock
 except ImportError:
@@ -20,7 +21,7 @@ class MockSetMeta(type):
         return obj
 
 
-class MockSet(MagicMock, metaclass=MockSetMeta):
+class MockSet(with_metaclass(MockSetMeta, MagicMock)):
     EVENT_ADDED = 'added'
     EVENT_UPDATED = 'updated'
     EVENT_SAVED = 'saved'

--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -13,7 +13,14 @@ from .utils import (
 )
 
 
-class MockSet(MagicMock):
+class MockSetMeta(type):
+    def __call__(cls, *initial_items, **kwargs):
+        obj = super(MockSetMeta, cls).__call__(**kwargs)
+        obj.add(*initial_items)
+        return obj
+
+
+class MockSet(MagicMock, metaclass=MockSetMeta):
     EVENT_ADDED = 'added'
     EVENT_UPDATED = 'updated'
     EVENT_SAVED = 'saved'


### PR DESCRIPTION
Fixes https://github.com/stphivos/django-mock-queries/issues/125 and https://github.com/stphivos/django-mock-queries/issues/113