### PR TITLE
pin pip for deprecated python versions <3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
       - TOX_ENV=py37-dj30-drf310
 
 install:
-  - travis_retry pip install "virtualenv~=14.0.0" "tox~=3.10.0" "coverage<4" "setuptools<40.0.0"
+  - travis_retry pip install "virtualenv~=14.0.0" "tox~=3.10.0" "coverage<4" "setuptools<40.0.0" "pip<21;python_version<'3.6'"
 
 script:
   - tox -ve $TOX_ENV


### PR DESCRIPTION
Pip removes support for py27 and py35 starting from version 21.
https://discuss.python.org/t/announcement-pip-20-3-release/5948

This fix will pin the version to the latest supported one.