### PR TITLE
Suppress UnorderedObjectListWarning when ordering MockSet

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -176,7 +176,7 @@ class MockSet(with_metaclass(MockSetMeta, MagicMock)):
             results = sorted(results,
                              key=lambda r: get_attribute(r, attr),
                              reverse=is_reversed)
-        return MockSet(*results, clone=self)
+        return MockSet(*results, clone=self, ordered=True)
 
     def distinct(self, *fields):
         results = OrderedDict()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -559,15 +559,15 @@ class TestQuery(TestCase):
         item_3 = MockModel(foo=2, bar='b', mock_name='item_3')
 
         self.mock_set.add(item_1, item_3, item_2)
-        
+
         qs = self.mock_set.order_by('foo', 'bar')
-        
+
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            paginator = Paginator(qs, 2)
-            
-            assert len(w) == 0
+            Paginator(qs, 2)
+
+            assert 0 == len(w)
 
     def test_query_distinct(self):
         item_1 = MockModel(foo=1, mock_name='item_1')

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -9,7 +9,7 @@ except ImportError:
 from unittest import TestCase
 
 from django.core.exceptions import FieldError
-from django.core.paginator import Paginator, UnorderedObjectListWarning
+from django.core.paginator import Paginator
 from django.db.models import Q, Avg
 
 from django_mock_queries.constants import *


### PR DESCRIPTION
Fixes issue https://github.com/stphivos/django-mock-queries/issues/138
Marking the mock object with `ordered=True` so that [this](https://github.com/django/django/blob/main/django/core/paginator.py#L121) check passes successfully and the warning isn't raised.