### PR TITLE
Loosen model-bakery dependency

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,4 +1,5 @@
 mock
 Django
 djangorestframework
-model-bakery~=1.1.0
+model-bakery~=1.1.0; python_version < '3'
+model-bakery==1.*; python_version >= '3'


### PR DESCRIPTION
This pinning is causing issues in my project because I want to use `model-bakery==1.2.1`.

Resolves #130.