### PR TITLE
Update supported versions of Python, Django & DRF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,43 +4,22 @@ language: python
 jobs:
   fast_finish: true
   include:
-    - python: 2.7
-      env:
-      - TOX_ENV=py27-dj19-drf33
-      - TOX_ENV=py27-dj110-drf33
-      - TOX_ENV=py27-dj111-drf37
-    - python: 3.5
-      env:
-      - TOX_ENV=py35-dj111-drf37
-      - TOX_ENV=py35-dj20-drf37
-      - TOX_ENV=py35-dj21-drf37
-      - TOX_ENV=py35-dj22-drf37
-      - TOX_ENV=py35-dj111-drf39
-      - TOX_ENV=py35-dj20-drf39
-      - TOX_ENV=py35-dj21-drf39
-      - TOX_ENV=py35-dj22-drf39
     - python: 3.6
       env:
-      - TOX_ENV=py36-dj111-drf37
-      - TOX_ENV=py36-dj20-drf37
-      - TOX_ENV=py36-dj21-drf37
-      - TOX_ENV=py36-dj22-drf37
-      - TOX_ENV=py36-dj111-drf39
-      - TOX_ENV=py36-dj20-drf39
-      - TOX_ENV=py36-dj21-drf39
-      - TOX_ENV=py36-dj22-drf39
-      - TOX_ENV=py36-dj30-drf310
+        - TOX_ENV=py36-dj22-drf39
+        - TOX_ENV=py36-dj22-drf310
+        - TOX_ENV=py36-dj31-drf39
+        - TOX_ENV=py36-dj31-drf310
+        - TOX_ENV=py36-dj32-drf39
+        - TOX_ENV=py36-dj32-drf310
     - python: 3.7
       env:
-      - TOX_ENV=py37-dj111-drf37
-      - TOX_ENV=py37-dj20-drf37
-      - TOX_ENV=py37-dj21-drf37
-      - TOX_ENV=py37-dj22-drf37
-      - TOX_ENV=py37-dj111-drf39
-      - TOX_ENV=py37-dj20-drf39
-      - TOX_ENV=py37-dj21-drf39
-      - TOX_ENV=py37-dj22-drf39
-      - TOX_ENV=py37-dj30-drf310
+        - TOX_ENV=py37-dj22-drf39
+        - TOX_ENV=py37-dj22-drf310
+        - TOX_ENV=py37-dj31-drf39
+        - TOX_ENV=py37-dj31-drf310
+        - TOX_ENV=py37-dj32-drf39
+        - TOX_ENV=py37-dj32-drf310
 
 install:
   - travis_retry pip install "tox~=3.22.0" "coverage<4" "setuptools<40.0.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 dist: xenial   # required for Python >= 3.7
 language: python
 
-sudo: false
-
 matrix:
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: xenial   # required for Python >= 3.7
 language: python
 
-matrix:
+jobs:
   fast_finish: true
   include:
     - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,22 @@ jobs:
         - TOX_ENV=py37-dj31-drf310
         - TOX_ENV=py37-dj32-drf39
         - TOX_ENV=py37-dj32-drf310
+    - python: 3.8
+      env:
+        - TOX_ENV=py38-dj22-drf39
+        - TOX_ENV=py38-dj22-drf310
+        - TOX_ENV=py38-dj31-drf39
+        - TOX_ENV=py38-dj31-drf310
+        - TOX_ENV=py38-dj32-drf39
+        - TOX_ENV=py38-dj32-drf310
+    - python: 3.9
+      env:
+        - TOX_ENV=py39-dj22-drf39
+        - TOX_ENV=py39-dj22-drf310
+        - TOX_ENV=py39-dj31-drf39
+        - TOX_ENV=py39-dj31-drf310
+        - TOX_ENV=py39-dj32-drf39
+        - TOX_ENV=py39-dj32-drf310
 
 install:
   - travis_retry pip install "tox~=3.22.0" "coverage<4" "setuptools<40.0.0"

--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -1,7 +1,6 @@
 import datetime
 import random
 from collections import OrderedDict, namedtuple
-from six import with_metaclass
 try:
     from unittest.mock import Mock, MagicMock, PropertyMock
 except ImportError:
@@ -21,7 +20,7 @@ class MockSetMeta(type):
         return obj
 
 
-class MockSet(with_metaclass(MockSetMeta, MagicMock)):
+class MockSet(MagicMock, metaclass=MockSetMeta):
     EVENT_ADDED = 'added'
     EVENT_UPDATED = 'updated'
     EVENT_SAVED = 'saved'

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,5 +9,3 @@ virtualenv==14.0.6
 pypandoc==1.4
 setuptools==39.2.0
 twine==1.11.0
-more-itertools<6.0.0; python_version < '3'
-configparser<5.0.0; python_version < '3'

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -22,14 +22,14 @@ BUILTINS = 'builtins' if sys.version_info[0] >= 3 else '__builtin__'
 class TestMocks(TestCase):
     def test_mock_sql_raises_error(self):
         """ Get a clear error if you forget to mock a database query. """
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 NotSupportedError,
                 "Mock database tried to execute SQL for Car model."):
             Car.objects.count()
 
     def test_exists_raises_error(self):
         """ Get a clear error if you forget to mock a database query. """
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 NotSupportedError,
                 "Mock database tried to execute SQL for Car model."):
             Car.objects.exists()
@@ -111,7 +111,7 @@ class MockOneToManyTests(TestCase):
     def test_not_mocked(self):
         m = Manufacturer()
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 NotSupportedError,
                 'Mock database tried to execute SQL for Car model'):
             m.car_set.count()
@@ -123,7 +123,7 @@ class MockOneToManyTests(TestCase):
             m.car_set = MockSet(Car(speed=95))
             self.assertEqual(1, m.car_set.count())
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 NotSupportedError,
                 'Mock database tried to execute SQL for Car model'):
             m.car_set.count()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -196,7 +196,7 @@ class TestQuery(TestCase):
         item_2.sedan = item_2
 
         self.mock_set.add(item_1, item_2, item_3)
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 FieldError,
                 r"Cannot resolve keyword 'bad_field' into field\. "
                 r"Choices are 'id', 'make', 'make_id', 'model', 'passengers', 'sedan', 'speed', 'variations'\."):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,7 +86,7 @@ class TestUtils(TestCase):
         assert comparison == (constants.COMPARISON_YEAR, constants.COMPARISON_EXACT)
 
     def test_validate_date_or_datetime_raises_value_error(self):
-        with self.assertRaisesRegexp(ValueError, r'13 is incorrect value for month'):
+        with self.assertRaisesRegex(ValueError, r'13 is incorrect value for month'):
             utils.validate_date_or_datetime(13, constants.COMPARISON_MONTH)
 
     def test_is_match_equality_check_when_comparison_none(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,7 @@
 [tox]
 # See https://docs.djangoproject.com/en/2.0/faq/install/#what-python-version-can-i-use-with-django
 envlist =
-    py{27}-dj{19,110}-drf33
-    py{27,35,36,37}-dj{111}-drf{37,39}
-    py{35,36,37}-dj{20,21,22}-drf{37,39}
-    py{36,37}-dj{30}-drf{310}
+    py{36,37}-dj{22,31,32}-drf{39,310}
 requires = virtualenv >= 20.0
 
 [pytest]
@@ -19,17 +16,11 @@ setenv =
     VIRTUALENV_DOWNLOAD=1
 deps =
     -rrequirements/dev.txt
-    dj19: Django~=1.9.12
-    dj110: Django~=1.10.5
-    dj111: Django~=1.11.17
-    dj20: Django~=2.0.2
-    dj21: Django~=2.1.0
-    dj22: Django~=2.2.1
-    dj30: Django~=3.0.3
-    drf33: djangorestframework~=3.3.2
-    drf37: djangorestframework~=3.7.7
-    drf39: djangorestframework~=3.9.2
-    drf310: djangorestframework~=3.10.3
+    dj22: Django==2.2.*
+    dj31: Django==3.1.*
+    dj32: Django==3.2.*
+    drf39: djangorestframework==3.9.*
+    drf310: djangorestframework==3.10.*
 
 commands =
     py.test django_mock_queries/ tests/ --cov-report term-missing --cov=django_mock_queries --flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # See https://docs.djangoproject.com/en/2.0/faq/install/#what-python-version-can-i-use-with-django
 envlist =
-    py{36,37}-dj{22,31,32}-drf{39,310}
+    py{36,37,38,39}-dj{22,31,32}-drf{39,310}
 requires = virtualenv >= 20.0
 
 [pytest]


### PR DESCRIPTION
Python 2.7 and 3.5 are no longer supported, as are Django 2.0, 2.1 and 3.0. DRF before 3.9 is pretty old, so I dropped support for that as well.

This PR should probably include some README updates and the change should trigger a major version bump.