### PR TITLE
Allow usage of Q objects on MockSet.get()

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -285,8 +285,8 @@ class MockSet(with_metaclass(MockSetMeta, MagicMock)):
     def remove(self, **attrs):
         return self.delete(**attrs)
 
-    def get(self, **attrs):
-        results = self.filter(**attrs)
+    def get(self, *args, **attrs):
+        results = self.filter(*args, **attrs)
         if not results.exists():
             self._raise_does_not_exist()
         elif results.count() > 1:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -709,6 +709,14 @@ class TestQuery(TestCase):
 
         assert item_2 == result
 
+    def test_query_gets_unique_match_by_q_object(self):
+        item_1 = MockModel(mock_name='#1', foo=1)
+        item_2 = MockModel(mock_name='#2', foo=2)
+        item_3 = MockModel(mock_name='#3', foo=3)
+
+        self.mock_set.add(item_1, item_2, item_3)
+        assert self.mock_set.get(Q(foo=1)) == item_1
+
     def test_query_get_raises_does_not_exist_when_no_match(self):
         item_1 = MockModel(foo=1)
         item_2 = MockModel(foo=2)


### PR DESCRIPTION
Currently the `.get()` method on the MockSet only allows for keyword arguments.
This prevents us from doing things such as:

```python
Model.objects.get(Q(foo=True) & (Q(bar=1) | Q(bar=2)))
```

This behavior is supported by Django, but not by django-mock-queries and is a pretty common use case.