### PR TITLE
Refactor deprecated unittest aliases for Python 3.11 compatibility.

### DIFF
--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -1,5 +1,6 @@
 import sys
 import django
+import six
 from django.db import connection
 from django.db.utils import NotSupportedError
 from django.db.backends.base.creation import BaseDatabaseCreation
@@ -22,14 +23,16 @@ BUILTINS = 'builtins' if sys.version_info[0] >= 3 else '__builtin__'
 class TestMocks(TestCase):
     def test_mock_sql_raises_error(self):
         """ Get a clear error if you forget to mock a database query. """
-        with self.assertRaisesRegexp(
+        with six.assertRaisesRegex(
+                self,
                 NotSupportedError,
                 "Mock database tried to execute SQL for Car model."):
             Car.objects.count()
 
     def test_exists_raises_error(self):
         """ Get a clear error if you forget to mock a database query. """
-        with self.assertRaisesRegexp(
+        with six.assertRaisesRegex(
+                self,
                 NotSupportedError,
                 "Mock database tried to execute SQL for Car model."):
             Car.objects.exists()
@@ -111,7 +114,8 @@ class MockOneToManyTests(TestCase):
     def test_not_mocked(self):
         m = Manufacturer()
 
-        with self.assertRaisesRegexp(
+        with six.assertRaisesRegex(
+                self,
                 NotSupportedError,
                 'Mock database tried to execute SQL for Car model'):
             m.car_set.count()
@@ -123,7 +127,8 @@ class MockOneToManyTests(TestCase):
             m.car_set = MockSet(Car(speed=95))
             self.assertEqual(1, m.car_set.count())
 
-        with self.assertRaisesRegexp(
+        with six.assertRaisesRegex(
+                self,
                 NotSupportedError,
                 'Mock database tried to execute SQL for Car model'):
             m.car_set.count()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,5 +1,6 @@
 import datetime
 import warnings
+import six
 
 try:
     from unittest.mock import MagicMock
@@ -196,7 +197,7 @@ class TestQuery(TestCase):
         item_2.sedan = item_2
 
         self.mock_set.add(item_1, item_2, item_3)
-        with self.assertRaisesRegexp(
+        with six.assertRaisesRegex(
                 FieldError,
                 r"Cannot resolve keyword 'bad_field' into field\. "
                 r"Choices are 'id', 'make', 'make_id', 'model', 'passengers', 'sedan', 'speed', 'variations'\."):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import six
 from datetime import date, datetime
 try:
     from unittest.mock import patch, MagicMock
@@ -86,7 +87,7 @@ class TestUtils(TestCase):
         assert comparison == (constants.COMPARISON_YEAR, constants.COMPARISON_EXACT)
 
     def test_validate_date_or_datetime_raises_value_error(self):
-        with self.assertRaisesRegexp(ValueError, r'13 is incorrect value for month'):
+        with six.assertRaisesRegex(self, ValueError, r'13 is incorrect value for month'):
             utils.validate_date_or_datetime(13, constants.COMPARISON_MONTH)
 
     def test_is_match_equality_check_when_comparison_none(self):


### PR DESCRIPTION
The deprecated aliases have been removed in python/cpython#28268