### PR TITLE
Support reverse foreign key filter by in comparison

### DIFF
--- a/django_mock_queries/comparisons.py
+++ b/django_mock_queries/comparisons.py
@@ -34,6 +34,9 @@ def lte_comparison(first, second):
 
 
 def in_comparison(first, second):
+    if isinstance(first, list):
+        return bool(set(first).intersection(set(second)))
+
     return first in second if first is not None else False
 
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -202,6 +202,18 @@ class TestQuery(TestCase):
                 r"Choices are 'id', 'make', 'make_id', 'model', 'passengers', 'sedan', 'speed', 'variations'\."):
             self.mock_set.filter(bad_field='bogus')
 
+    def test_query_filters_reverse_relationship_by_in_comparison(self):
+        with mocked_relations(Manufacturer):
+            cars = [Car(speed=1)]
+
+            make = Manufacturer()
+            make.car_set = MockSet(*cars)
+
+            self.mock_set.add(make)
+
+            result = self.mock_set.filter(car__speed__in=[1, 2])
+            assert result.count() == 1
+
     def test_query_exclude(self):
         item_1 = MockModel(foo=1, bar='a')
         item_2 = MockModel(foo=1, bar='b')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -227,6 +227,12 @@ class TestUtils(TestCase):
         result = utils.is_match(1, [1, 3], constants.COMPARISON_IN)
         assert result is True
 
+        result = utils.is_match([3], [1, 2], constants.COMPARISON_IN)
+        assert result is False
+
+        result = utils.is_match([1, 3], [1, 2], constants.COMPARISON_IN)
+        assert result is True
+
     @patch('django_mock_queries.utils.get_attribute')
     @patch('django_mock_queries.utils.is_match', MagicMock(return_value=True))
     def test_matches_includes_object_in_results_when_match(self, get_attr_mock):


### PR DESCRIPTION
### Issue

The `in_comparison` currently does not support lookup by a reverse foreign key relationship.

Example with `Car` and `Manufacturer` (where `Manufacturer`  is a foreign key on `Car`):

```python
man = Manufacturer()
car_1 = Car(manufacture=man)  # id = 1
car_2 = Car(manufacture=man)
# This will break `in_comparison`: `first` is a list of the two car IDs, and `second` is [...].
# Currently the function is defined as `return first in second` which does not capture this scenario
Manufacturer.objects.filter(car__id__in=[...])
```

### Changes:

- Updated `in_comparison` to take the intersection of the two if `first` is a list
- Added tests