### PR TITLE
Use standalone mocks in isinstance check

### DIFF
--- a/django_mock_queries/mocks.py
+++ b/django_mock_queries/mocks.py
@@ -9,6 +9,7 @@ from django.db.models import Model
 from django.db.utils import ConnectionHandler, NotSupportedError
 from functools import partial
 from itertools import chain
+import mock as standalone_mock
 try:
     from unittest.mock import Mock, MagicMock, patch, PropertyMock
 except ImportError:
@@ -227,7 +228,7 @@ def mocked_relations(*models):
     patchers = []
 
     for model in find_all_models(models):
-        if isinstance(model.save, Mock):
+        if isinstance(model.save, (Mock, standalone_mock.Mock)):
             # already mocked, so skip it
             continue
 

--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -6,6 +6,7 @@ try:
     from unittest.mock import Mock, MagicMock, PropertyMock
 except ImportError:
     from mock import Mock, MagicMock, PropertyMock
+import mock as standalone_mock
 
 from .constants import *
 from .exceptions import *
@@ -78,7 +79,7 @@ class MockSet(with_metaclass(MockSetMeta, MagicMock)):
         self.events[event] = self.events.get(event, []) + [handler]
 
     def _register_fields(self, obj):
-        if not (isinstance(obj, MockModel) or isinstance(obj, Mock)):
+        if not (isinstance(obj, MockModel) or isinstance(obj, Mock) or isinstance(obj, standalone_mock.Mock)):
             return
 
         for f in self.model._meta.fields:

--- a/django_mock_queries/utils.py
+++ b/django_mock_queries/utils.py
@@ -4,6 +4,7 @@ try:
     from unittest.mock import Mock
 except ImportError:
     from mock import Mock
+import mock as standalone_mock
 
 from .comparisons import *
 from .constants import *
@@ -245,7 +246,7 @@ def is_list_like_iter(obj):
         return False
     elif isinstance(obj, django_mock_queries.query.MockSet):
         return True
-    elif isinstance(obj, Mock):
+    elif isinstance(obj, (Mock, standalone_mock.Mock)):
         return False
 
     return hasattr(obj, '__iter__') and not isinstance(obj, str)


### PR DESCRIPTION
Our team is using pytest-mock with `mock_use_standalone_module = true` for a while. changing this to `false` is an easy change, but we have usages of the standalone package everywhere in our test suite.

The change to use exclusively one or the other in a (not so recent) change breaks some of our test cases.

Would it be possible to add the standalone mock to some of the `isinstance` calls to prevent similar problems?