### PR TITLE
Only require `mock` package on Python < 3.3

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,4 +1,4 @@
-mock
+mock; python_version < '3.3'
 Django
 djangorestframework
 model-bakery~=1.1.0; python_version < '3'


### PR DESCRIPTION
The `mock` package is not required on Python >= 3.3, see https://pypi.org/project/mock/