### PR TITLE
Bring changelog up-to-date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,221 @@
-# Change Log
+# Changelog
+
+## [Unreleased](https://github.com/stphivos/django-mock-queries/tree/HEAD)
+
+[Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v2.1.7...HEAD)
+
+**Implemented enhancements:**
+
+- Implement `annotate` and `in_bulk` \(updated\) [\#156](https://github.com/stphivos/django-mock-queries/pull/156) ([phitranphitranphitran](https://github.com/phitranphitranphitran))
+- Return a new object of the same type instead of forcing MockSet [\#155](https://github.com/stphivos/django-mock-queries/pull/155) ([lvieirajr](https://github.com/lvieirajr))
+
+**Closed issues:**
+
+- Review MockSet implementation for better inheritance behaviour [\#150](https://github.com/stphivos/django-mock-queries/issues/150)
+- UnorderedObjectListWarning raised even when ordering the MockSet [\#138](https://github.com/stphivos/django-mock-queries/issues/138)
+
+**Merged pull requests:**
+
+- Improve README [\#167](https://github.com/stphivos/django-mock-queries/pull/167) ([stefan6419846](https://github.com/stefan6419846))
+- Fix tests for Django 3.2 and Django 4.1 [\#166](https://github.com/stphivos/django-mock-queries/pull/166) ([stefan6419846](https://github.com/stefan6419846))
+- Drop Python 2 code and avoid deprecated code [\#164](https://github.com/stphivos/django-mock-queries/pull/164) ([stefan6419846](https://github.com/stefan6419846))
+- Migrate CI to github actions [\#163](https://github.com/stphivos/django-mock-queries/pull/163) ([stphivos](https://github.com/stphivos))
+- Only require `mock` package on Python \< 3.3 [\#161](https://github.com/stphivos/django-mock-queries/pull/161) ([stefan6419846](https://github.com/stefan6419846))
+- Support reverse foreign key filter by in comparison [\#153](https://github.com/stphivos/django-mock-queries/pull/153) ([karally](https://github.com/karally))
+- Allow usage of Q objects on MockSet.get\(\) [\#147](https://github.com/stphivos/django-mock-queries/pull/147) ([lvieirajr](https://github.com/lvieirajr))
+- Adding overlap operator for ArrayFields [\#143](https://github.com/stphivos/django-mock-queries/pull/143) ([lvieirajr](https://github.com/lvieirajr))
+
+## [v2.1.7](https://github.com/stphivos/django-mock-queries/tree/v2.1.7) (2021-09-12)
+
+[Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v2.1.6...v2.1.7)
+
+**Closed issues:**
+
+- Release date 2.1.6 [\#131](https://github.com/stphivos/django-mock-queries/issues/131)
+- Loosen model-bakery dependency [\#130](https://github.com/stphivos/django-mock-queries/issues/130)
+- Support for QuerySet.iterator\(\) [\#94](https://github.com/stphivos/django-mock-queries/issues/94)
+
+**Merged pull requests:**
+
+- Improve flaky test for query order by random [\#145](https://github.com/stphivos/django-mock-queries/pull/145) ([stphivos](https://github.com/stphivos))
+- Remove dollar sign from example commands [\#144](https://github.com/stphivos/django-mock-queries/pull/144) ([1oglop1](https://github.com/1oglop1))
+- Loosen model-bakery dependency [\#140](https://github.com/stphivos/django-mock-queries/pull/140) ([allanlewis](https://github.com/allanlewis))
+- Suppress UnorderedObjectListWarning when ordering MockSet [\#139](https://github.com/stphivos/django-mock-queries/pull/139) ([thatguysimon](https://github.com/thatguysimon))
+
+## [v2.1.6](https://github.com/stphivos/django-mock-queries/tree/v2.1.6) (2021-02-21)
+
+[Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v2.1.5...v2.1.6)
+
+**Closed issues:**
+
+- MockSet constructor limited to 11 elements on Python 3.8 [\#125](https://github.com/stphivos/django-mock-queries/issues/125)
+- Error if use order\_by random [\#119](https://github.com/stphivos/django-mock-queries/issues/119)
+- MockModel never "in" MockSet in Python 2.7  [\#117](https://github.com/stphivos/django-mock-queries/issues/117)
+- Limit in MockModel number inside MockSet? [\#113](https://github.com/stphivos/django-mock-queries/issues/113)
+- README.md typo [\#106](https://github.com/stphivos/django-mock-queries/issues/106)
+- Filter with empty Q object doesn't work as expected [\#102](https://github.com/stphivos/django-mock-queries/issues/102)
+
+**Merged pull requests:**
+
+- Fix tox for ci [\#134](https://github.com/stphivos/django-mock-queries/pull/134) ([mdalp](https://github.com/mdalp))
+- Support for QuerySet.iterator\(\) [\#132](https://github.com/stphivos/django-mock-queries/pull/132) ([platonfloria](https://github.com/platonfloria))
+- Fix MockSet too many positional arguments error in python 3.8 [\#129](https://github.com/stphivos/django-mock-queries/pull/129) ([stphivos](https://github.com/stphivos))
+- Fix bug on empty DjangoQ [\#128](https://github.com/stphivos/django-mock-queries/pull/128) ([stphivos](https://github.com/stphivos))
+- Fix order\_by random [\#127](https://github.com/stphivos/django-mock-queries/pull/127) ([stphivos](https://github.com/stphivos))
+- Update packages, drop unsupported Django versions with python 2.7, 3.5 [\#126](https://github.com/stphivos/django-mock-queries/pull/126) ([stphivos](https://github.com/stphivos))
+- \#106 - add import to README [\#124](https://github.com/stphivos/django-mock-queries/pull/124) ([shinneider](https://github.com/shinneider))
+- Build universal wheel [\#122](https://github.com/stphivos/django-mock-queries/pull/122) ([allanlewis](https://github.com/allanlewis))
+- Use unittest.mock when available instead of mock. [\#121](https://github.com/stphivos/django-mock-queries/pull/121) ([Gabriel-Fontenelle](https://github.com/Gabriel-Fontenelle))
+- Fix the problem that MockModel never "in" MockSet [\#118](https://github.com/stphivos/django-mock-queries/pull/118) ([mapx](https://github.com/mapx))
+- Add query named values list [\#116](https://github.com/stphivos/django-mock-queries/pull/116) ([stphivos](https://github.com/stphivos))
+
+## [v2.1.5](https://github.com/stphivos/django-mock-queries/tree/v2.1.5) (2020-05-04)
+
+[Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v2.1.4...v2.1.5)
+
+**Closed issues:**
+
+- Build is broken with pip 20.1 [\#111](https://github.com/stphivos/django-mock-queries/issues/111)
+- Add support for Django 3 [\#104](https://github.com/stphivos/django-mock-queries/issues/104)
+
+**Merged pull requests:**
+
+- Remove dependency on internal pip APIs [\#112](https://github.com/stphivos/django-mock-queries/pull/112) ([rbusquet](https://github.com/rbusquet))
+
+## [v2.1.4](https://github.com/stphivos/django-mock-queries/tree/v2.1.4) (2020-03-02)
+
+[Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v2.1.3...v2.1.4)
+
+**Closed issues:**
+
+- Values list doesn't act as expected [\#103](https://github.com/stphivos/django-mock-queries/issues/103)
+
+**Merged pull requests:**
+
+- Add support for Django 3.0.x [\#109](https://github.com/stphivos/django-mock-queries/pull/109) ([stphivos](https://github.com/stphivos))
+- Replace model-mommy with model-bakery [\#108](https://github.com/stphivos/django-mock-queries/pull/108) ([stphivos](https://github.com/stphivos))
+- Extend get\_field\_values to work for date/datetime objects [\#101](https://github.com/stphivos/django-mock-queries/pull/101) ([brianzhou13](https://github.com/brianzhou13))
+
+## [v2.1.3](https://github.com/stphivos/django-mock-queries/tree/v2.1.3) (2019-05-04)
+
+[Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v2.1.2...v2.1.3)
+
+**Closed issues:**
+
+- Breaking changes in 2.1.2: ignored filtered elements [\#96](https://github.com/stphivos/django-mock-queries/issues/96)
+
+**Merged pull requests:**
+
+- Use compatible release clause in tox deps versions [\#100](https://github.com/stphivos/django-mock-queries/pull/100) ([stphivos](https://github.com/stphivos))
+- Add failing test with falsy comparable value [\#99](https://github.com/stphivos/django-mock-queries/pull/99) ([stphivos](https://github.com/stphivos))
+- Django Dependency Issues [\#98](https://github.com/stphivos/django-mock-queries/pull/98) ([ish-vasa](https://github.com/ish-vasa))
+- Fix 96: check if value is None, and do not rely on boolean conversion [\#97](https://github.com/stphivos/django-mock-queries/pull/97) ([dannywillems](https://github.com/dannywillems))
+
+## [v2.1.2](https://github.com/stphivos/django-mock-queries/tree/v2.1.2) (2019-04-27)
+
+[Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v2.1.1...v2.1.2)
+
+**Closed issues:**
+
+- Mocking serializer: ListSerializer object is not callable [\#91](https://github.com/stphivos/django-mock-queries/issues/91)
+
+**Merged pull requests:**
+
+- Add support for Django 2.2 and Python 3.7 [\#95](https://github.com/stphivos/django-mock-queries/pull/95) ([m3brown](https://github.com/m3brown))
+- Exclude none row from filter comparison [\#93](https://github.com/stphivos/django-mock-queries/pull/93) ([stphivos](https://github.com/stphivos))
+- Exclude none row from filter comparison [\#92](https://github.com/stphivos/django-mock-queries/pull/92) ([tlfung0219](https://github.com/tlfung0219))
+
+## [v2.1.1](https://github.com/stphivos/django-mock-queries/tree/v2.1.1) (2018-08-09)
+
+[Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v2.1.0...v2.1.1)
+
+## [v2.1.0](https://github.com/stphivos/django-mock-queries/tree/v2.1.0) (2018-08-09)
+
+[Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v2.0.1...v2.1.0)
+
+**Closed issues:**
+
+- MockSet doesn't seem to copy all of its related model's properties. [\#88](https://github.com/stphivos/django-mock-queries/issues/88)
+
+**Merged pull requests:**
+
+- Bump django version lock [\#89](https://github.com/stphivos/django-mock-queries/pull/89) ([dmastylo](https://github.com/dmastylo))
+- Fix MockSet empty querysets evaluated to False when converted to bool in py27 [\#87](https://github.com/stphivos/django-mock-queries/pull/87) ([stphivos](https://github.com/stphivos))
+- Fix: Empty querysets should be evaluated to False when converted to boolean [\#86](https://github.com/stphivos/django-mock-queries/pull/86) ([mannysz](https://github.com/mannysz))
+- Missing range in comparisons list [\#85](https://github.com/stphivos/django-mock-queries/pull/85) ([rbusquet](https://github.com/rbusquet))
+
+## [v2.0.1](https://github.com/stphivos/django-mock-queries/tree/v2.0.1) (2018-05-18)
+
+[Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v2.0.0...v2.0.1)
+
+**Closed issues:**
+
+- Filter by attribute with False value is not working [\#83](https://github.com/stphivos/django-mock-queries/issues/83)
+- Plans for releasing `MockSet` as a child of `MagicMock`? [\#81](https://github.com/stphivos/django-mock-queries/issues/81)
+
+**Merged pull requests:**
+
+- Fixing filtering with boolean fields. [\#84](https://github.com/stphivos/django-mock-queries/pull/84) ([zuzelvp](https://github.com/zuzelvp))
+
+## [v2.0.0](https://github.com/stphivos/django-mock-queries/tree/v2.0.0) (2018-04-21)
+
+[Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v1.0.7...v2.0.0)
+
+**Closed issues:**
+
+- Incompatible with pip 10.0.0 [\#80](https://github.com/stphivos/django-mock-queries/issues/80)
+- `.distinct\(\)` when using a regular model: 'ModelName has no attribute items` [\#77](https://github.com/stphivos/django-mock-queries/issues/77)
+
+**Merged pull requests:**
+
+- ISSUE-80 Added pip==10.0 compatibility [\#82](https://github.com/stphivos/django-mock-queries/pull/82) ([khudyakovavi](https://github.com/khudyakovavi))
+- Adds support for update\_or\_create [\#79](https://github.com/stphivos/django-mock-queries/pull/79) ([rbusquet](https://github.com/rbusquet))
+- Fix hash\_dict to use concrete fields with django models [\#78](https://github.com/stphivos/django-mock-queries/pull/78) ([stphivos](https://github.com/stphivos))
+- Refactor maintainability issues on complexity part 2 [\#76](https://github.com/stphivos/django-mock-queries/pull/76) ([stphivos](https://github.com/stphivos))
+- Refactor maintainability issues on complexity part 1 [\#75](https://github.com/stphivos/django-mock-queries/pull/75) ([stphivos](https://github.com/stphivos))
+- Refactor more maintainability issues on duplication [\#74](https://github.com/stphivos/django-mock-queries/pull/74) ([stphivos](https://github.com/stphivos))
+- Refactor maintainability issues on duplication [\#73](https://github.com/stphivos/django-mock-queries/pull/73) ([stphivos](https://github.com/stphivos))
+- Attempt to improve performance of MockSet by reducing the use of MagicMock. [\#71](https://github.com/stphivos/django-mock-queries/pull/71) ([zuzelvp](https://github.com/zuzelvp))
+
+## [v1.0.7](https://github.com/stphivos/django-mock-queries/tree/v1.0.7) (2018-03-03)
+
+[Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v1.0.6...v1.0.7)
+
+**Closed issues:**
+
+- Support for Django 2.0 [\#69](https://github.com/stphivos/django-mock-queries/issues/69)
+- values\(\).distinct\(\)fails with TypeError: unhashable type: 'dict' [\#65](https://github.com/stphivos/django-mock-queries/issues/65)
+
+**Merged pull requests:**
+
+- Add support for Django 2 [\#72](https://github.com/stphivos/django-mock-queries/pull/72) ([stphivos](https://github.com/stphivos))
+- Add MockSet write event triggers, improve model mocker orm simulation. [\#70](https://github.com/stphivos/django-mock-queries/pull/70) ([stphivos](https://github.com/stphivos))
+- Feature/qs update delete [\#68](https://github.com/stphivos/django-mock-queries/pull/68) ([stphivos](https://github.com/stphivos))
+- Omit call to save in MockSet.create [\#67](https://github.com/stphivos/django-mock-queries/pull/67) ([stphivos](https://github.com/stphivos))
+- Improving implementation for distinct\(\) [\#66](https://github.com/stphivos/django-mock-queries/pull/66) ([zuzelvp](https://github.com/zuzelvp))
+
+## [v1.0.6](https://github.com/stphivos/django-mock-queries/tree/v1.0.6) (2018-02-13)
+
+[Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v1.0.5...v1.0.6)
+
+**Closed issues:**
+
+- AND operator is not handled properly causing random tests [\#60](https://github.com/stphivos/django-mock-queries/issues/60)
+
+**Merged pull requests:**
+
+- Add python 3.5 to build matrix [\#64](https://github.com/stphivos/django-mock-queries/pull/64) ([stphivos](https://github.com/stphivos))
+- Carta issues 60 and false positives [\#63](https://github.com/stphivos/django-mock-queries/pull/63) ([stphivos](https://github.com/stphivos))
+- Fix failing test due to hardcoded year value 2017 [\#62](https://github.com/stphivos/django-mock-queries/pull/62) ([stphivos](https://github.com/stphivos))
+- Issues 60 AND false positives [\#61](https://github.com/stphivos/django-mock-queries/pull/61) ([zuzelvp](https://github.com/zuzelvp))
+- Keep the previous name for decorated methods, functions and classes [\#58](https://github.com/stphivos/django-mock-queries/pull/58) ([grabekm90](https://github.com/grabekm90))
 
 ## [v1.0.5](https://github.com/stphivos/django-mock-queries/tree/v1.0.5) (2017-11-30)
+
 [Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v1.0.4...v1.0.5)
 
 ## [v1.0.4](https://github.com/stphivos/django-mock-queries/tree/v1.0.4) (2017-11-30)
+
 [Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v1.0.2...v1.0.4)
 
 **Fixed bugs:**
@@ -17,6 +229,7 @@
 - Fix a missed model parameter for MockSet in ModelMocker [\#55](https://github.com/stphivos/django-mock-queries/pull/55) ([grabekm90](https://github.com/grabekm90))
 
 ## [v1.0.2](https://github.com/stphivos/django-mock-queries/tree/v1.0.2) (2017-10-16)
+
 [Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v1.0.0...v1.0.2)
 
 **Merged pull requests:**
@@ -24,6 +237,7 @@
 - Fix hardcoded requirement to six library [\#53](https://github.com/stphivos/django-mock-queries/pull/53) ([stphivos](https://github.com/stphivos))
 
 ## [v1.0.0](https://github.com/stphivos/django-mock-queries/tree/v1.0.0) (2017-10-15)
+
 [Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v0.0.16...v1.0.0)
 
 **Closed issues:**
@@ -42,6 +256,7 @@
 - Update model-mommy req [\#44](https://github.com/stphivos/django-mock-queries/pull/44) ([orf](https://github.com/orf))
 
 ## [v0.0.16](https://github.com/stphivos/django-mock-queries/tree/v0.0.16) (2017-03-14)
+
 [Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v0.0.15...v0.0.16)
 
 **Merged pull requests:**
@@ -51,6 +266,7 @@
 - Fix one-to-many field lookup to use model name [\#41](https://github.com/stphivos/django-mock-queries/pull/41) ([stphivos](https://github.com/stphivos))
 
 ## [v0.0.15](https://github.com/stphivos/django-mock-queries/tree/v0.0.15) (2017-03-06)
+
 [Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v0.0.14...v0.0.15)
 
 **Merged pull requests:**
@@ -67,6 +283,7 @@
 - Add mocked\_relations decorator for all related models. [\#28](https://github.com/stphivos/django-mock-queries/pull/28) ([donkirkby](https://github.com/donkirkby))
 
 ## [v0.0.14](https://github.com/stphivos/django-mock-queries/tree/v0.0.14) (2016-12-15)
+
 [Full Changelog](https://github.com/stphivos/django-mock-queries/compare/v0.0.13...v0.0.14)
 
 **Merged pull requests:**
@@ -74,30 +291,16 @@
 - Upload v0.0.14 to PyPI [\#25](https://github.com/stphivos/django-mock-queries/pull/25) ([stphivos](https://github.com/stphivos))
 - Feature/aggregate multi params [\#24](https://github.com/stphivos/django-mock-queries/pull/24) ([szykin](https://github.com/szykin))
 - Mock django db [\#23](https://github.com/stphivos/django-mock-queries/pull/23) ([donkirkby](https://github.com/donkirkby))
-- added spec\_set to MockModel [\#22](https://github.com/stphivos/django-mock-queries/pull/22) ([szykin](https://github.com/szykin))
-- Mocked querysets aggregation now handles None values. [\#21](https://github.com/stphivos/django-mock-queries/pull/21) ([szykin](https://github.com/szykin))
-- Complete test coverage by testing with a real Django Q object. [\#19](https://github.com/stphivos/django-mock-queries/pull/19) ([donkirkby](https://github.com/donkirkby))
-- Raise an error when there's a typo in a queryset's field name. [\#18](https://github.com/stphivos/django-mock-queries/pull/18) ([donkirkby](https://github.com/donkirkby))
-- Update py-test requirement versions and add pip-tools [\#15](https://github.com/stphivos/django-mock-queries/pull/15) ([stphivos](https://github.com/stphivos))
-- Skipfieldfix [\#14](https://github.com/stphivos/django-mock-queries/pull/14) ([donkirkby](https://github.com/donkirkby))
-- Version 3 of flake8 contains breaking changes, so pin requirement. [\#13](https://github.com/stphivos/django-mock-queries/pull/13) ([donkirkby](https://github.com/donkirkby))
-
-## [v0.0.13](https://github.com/stphivos/django-mock-queries/tree/v0.0.13) (2016-06-08)
-**Merged pull requests:**
-
-- Add distinct\(\) to MockSet. [\#12](https://github.com/stphivos/django-mock-queries/pull/12) ([donkirkby](https://github.com/donkirkby))
-- Add first\(\) and last\(\) to MockSet. [\#11](https://github.com/stphivos/django-mock-queries/pull/11) ([donkirkby](https://github.com/donkirkby))
-- Add support for values list and individual attrs projection [\#10](https://github.com/stphivos/django-mock-queries/pull/10) ([stphivos](https://github.com/stphivos))
-- Use generic mock\_set clone for init [\#9](https://github.com/stphivos/django-mock-queries/pull/9) ([stphivos](https://github.com/stphivos))
-- Add order\_by\(\) to MockSet\(\) [\#8](https://github.com/stphivos/django-mock-queries/pull/8) ([donkirkby](https://github.com/donkirkby))
-- Add exclude\(\) to MockSet [\#7](https://github.com/stphivos/django-mock-queries/pull/7) ([donkirkby](https://github.com/donkirkby))
-- In and isnull [\#6](https://github.com/stphivos/django-mock-queries/pull/6) ([donkirkby](https://github.com/donkirkby))
 - django-rest-framework serializer assert function [\#5](https://github.com/stphivos/django-mock-queries/pull/5) ([stphivos](https://github.com/stphivos))
 - Test remaining crud functions and exception scenarios [\#4](https://github.com/stphivos/django-mock-queries/pull/4) ([stphivos](https://github.com/stphivos))
 - Test query aggregate, create and get functionality [\#3](https://github.com/stphivos/django-mock-queries/pull/3) ([stphivos](https://github.com/stphivos))
 - Fix and test query filtering by q objects [\#2](https://github.com/stphivos/django-mock-queries/pull/2) ([stphivos](https://github.com/stphivos))
 - Fix/remove pytest ini [\#1](https://github.com/stphivos/django-mock-queries/pull/1) ([stphivos](https://github.com/stphivos))
 
+## [v0.0.13](https://github.com/stphivos/django-mock-queries/tree/v0.0.13) (2016-06-08)
+
+[Full Changelog](https://github.com/stphivos/django-mock-queries/compare/7c9d6917856d495c15fcee3b058a8e3eecd267b2...v0.0.13)
 
 
-\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*
+
+\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*


### PR DESCRIPTION
Bring the changelog up-to-date. Closes #165.

For future reference:

```
docker run -it --rm -v "$(pwd)" githubchangeloggenerator/github-changelog-generator -u stphivos -p django-mock-queries -t ghp_XXX -o ''
```