### PR TITLE
Fix in_bulk to use field_name

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -114,7 +114,7 @@ class MockSet(MagicMock, metaclass=MockSetMeta):
     def in_bulk(self, id_list=None, *, field_name='pk'):
         result = {}
         for model in self.items:
-            if id_list is None or model.pk in id_list:
+            if id_list is None or getattr(model, field_name) in id_list:
                 result[getattr(model, field_name)] = model
         return result
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1024,7 +1024,7 @@ class TestQuery(TestCase):
         qs = MockSet(golf, polo, kia)
 
         self.assertEqual(qs.in_bulk(), {1: golf, 2: polo, 4: kia})
-        self.assertEqual(qs.in_bulk(id_list=[4], field_name='model'), {'kia': kia})
+        self.assertEqual(qs.in_bulk(id_list=['kia'], field_name='model'), {'kia': kia})
 
     def test_annotate(self):
         qs = MockSet(CarVariation(color='green', car=Car(model='golf', id=1), id=1),


### PR DESCRIPTION
There was a bug in the `in_bulk` method that would only allow `field_name` to be `pk`