### PR TITLE
#171: Contains comparison supports arrays

### DIFF
--- a/django_mock_queries/comparisons.py
+++ b/django_mock_queries/comparisons.py
@@ -10,7 +10,7 @@ def iexact_comparison(first, second):
 
 
 def contains_comparison(first, second):
-    if isinstance(first, list) or isinstance(first, tuple):
+    if isinstance(first, (list, tuple)):
         return set(second).issubset(first)
 
     return second in first

--- a/django_mock_queries/comparisons.py
+++ b/django_mock_queries/comparisons.py
@@ -10,6 +10,9 @@ def iexact_comparison(first, second):
 
 
 def contains_comparison(first, second):
+    if isinstance(first, list) or isinstance(first, tuple):
+        return set(second).issubset(first)
+
     return second in first
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -116,6 +116,19 @@ class TestUtils(TestCase):
         result = utils.is_match('abc', 'a', constants.COMPARISON_CONTAINS)
         assert result is True
 
+    def test_is_match_case_list_contains_check(self):
+        result = utils.is_match([1, 2, 3], [1, 2], constants.COMPARISON_CONTAINS)
+        assert result is True
+
+        result = utils.is_match([1, 2, 3], [1, 4], constants.COMPARISON_CONTAINS)
+        assert result is False
+
+        result = utils.is_match((1, 2, 3), (1, 2), constants.COMPARISON_CONTAINS)
+        assert result is True
+
+        result = utils.is_match((1, 2, 3), (1, 2,3, 4), constants.COMPARISON_CONTAINS)
+        assert result is False
+
     def test_is_match_case_insensitive_contains_check(self):
         result = utils.is_match('abc', 'A', constants.COMPARISON_ICONTAINS)
         assert result is True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -126,7 +126,7 @@ class TestUtils(TestCase):
         result = utils.is_match((1, 2, 3), (1, 2), constants.COMPARISON_CONTAINS)
         assert result is True
 
-        result = utils.is_match((1, 2, 3), (1, 2,3, 4), constants.COMPARISON_CONTAINS)
+        result = utils.is_match((1, 2, 3), (1, 2, 3, 4), constants.COMPARISON_CONTAINS)
         assert result is False
 
     def test_is_match_case_insensitive_contains_check(self):


### PR DESCRIPTION
This PRs fixes "bug" #171.
Contains comparison now support lists and tuples