### PR TITLE
#173: Use attname instead of name when assigning the attributes values on the mocked _do_update

### DIFF
--- a/django_mock_queries/mocks.py
+++ b/django_mock_queries/mocks.py
@@ -476,7 +476,7 @@ class ModelMocker(Mocker):
         objects = self.objects.filter(pk=pk_val)
 
         if objects.exists():
-            attrs = {field.name: value for field, _, value in values if value is not None}
+            attrs = {field.attname: value for field, _, value in values if value is not None}
             self.objects.update(**attrs)
             return True
         else:

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -435,6 +435,16 @@ class TestMockers(TestCase):
             obj = Car.objects.create(speed=10)
             self.assertEqual(Car.objects.get(pk=obj.id), obj)
 
+    def test_model_mocker_update_fk_from_instance(self):
+        with ModelMocker(Manufacturer):
+            with ModelMocker(Car, outer=False):
+                manufacturer = Manufacturer.objects.create(name='foo')
+                obj = Car.objects.create(speed=10, make=manufacturer)
+                obj.make = Manufacturer.objects.create(name='bar')
+                obj.save()
+
+                self.assertEqual(Car.objects.get(pk=obj.id).make.name, 'bar')
+
     def test_model_mocker_with_custom_method(self):
         with self.CarModelMocker(Car, 'validate_price') as mocker:
             obj = Car()


### PR DESCRIPTION
This PR fixes bug #173.
ModelMocker._do_update now uses fields attname instead of name to support assigning PKs instead of instances to FK fields