### PR TITLE
Make annotate return instance of actual MockSet class

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -127,7 +127,7 @@ class MockSet(MagicMock, metaclass=MockSetMeta):
                 row._annotated_fields.append(key)
                 setattr(row, key, get_attribute(row, value)[0])
 
-        return MockSet(*results, clone=self)
+        return self._mockset_class()(*results, clone=self)
 
     def aggregate(self, *args, **kwargs):
         result = {}

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1090,6 +1090,13 @@ class TestQuery(TestCase):
 
         self.assertEqual(qs[2].color_or_car, 'kia')
 
+    def test_annotate_returns_current_class_instance(self):
+        class CustomMockSet(MockSet):
+            pass
+
+        qs = CustomMockSet(Car(model='golf', id=1))
+        self.assertIsInstance(qs.annotate(model=models.F('model')), CustomMockSet)
+
     def test_query_values_raises_attribute_error_when_field_is_not_in_meta_concrete_fields(self):
         qs = MockSet(MockModel(foo=1), MockModel(foo=2))
         self.assertRaises(FieldError, qs.values, 'bar')


### PR DESCRIPTION
While other `MockSet` methods, such as `exclude` or `filter`, return an instance of the actual `MockSet` class being used,  `annotate` doesn't.

This fixes that.