### PR TITLE
Add set method to MockSet

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -183,6 +183,10 @@ class MockSet(MagicMock, metaclass=MockSetMeta):
                 results[key] = item
         return self._mockset_class()(*results.values(), clone=self)
 
+    def set(self, objs, **attrs):
+        self.delete(**attrs)
+        self.add(*objs)
+
     def _raise_does_not_exist(self):
         does_not_exist = getattr(self.model, 'DoesNotExist', ObjectDoesNotExist)
         raise does_not_exist()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1383,3 +1383,13 @@ class TestQuery(TestCase):
         )
         field1 = mockset.annotate(field1=models.F("nested_mock__field1")).values_list("field1")[0][0]
         assert field1 == "field_value"
+
+    def test_set_replaces_all_items(self):
+        mockset = MockSet(
+            MockModel(id=1, field="value_1", mock_name="item1"),
+            MockModel(id=2, field="value_2", mock_name="item2"),
+        )
+        mockset.set([MockModel(id=3, field="value_3", mock_name="item3")])
+
+        assert len(mockset) == 1
+        assert mockset[0].id == 3


### PR DESCRIPTION
Currently, trying to mock the following scenario raises an `AttributeError`.

```python
class Other(models.Model): ...

class MyModel(models.Model):
    others = models.ManyToManyField("Other", through="OtherModel")

with mocked_relations(MyModel, Other):
    model = MyModel.objects.get(id=1234)
    model.others.set([]) # AttributeError: Mock object has no attribute 'set'`.
```

This PR adds a mock implementation for [`RelatedManager.set` field](https://docs.djangoproject.com/en/5.1/ref/models/relations/#django.db.models.fields.related.RelatedManager.set), supporting the above use case.