### PR TITLE
Fix calling `delete` on instances using nested `ModelMocker` context managers

### DIFF
--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -486,6 +486,27 @@ class TestMockers(TestCase):
         self.assertIsInstance(objects['added'], Car)
         self.assertEqual(objects['added'], objects['car'])
 
+    def test_model_mocker_delete_from_instance_with_nested_context_manager(self):
+
+        def create_delete_models():
+            car = Car.objects.create(speed=10)
+            car.delete()
+
+            manufacturer = Manufacturer.objects.create(name='foo')
+            manufacturer.delete()
+
+        def models_exist():
+            return Manufacturer.objects.exists() or Car.objects.exists()
+
+        with ModelMocker(Manufacturer), ModelMocker(Car):
+            create_delete_models()
+            assert not models_exist()
+
+        # Test same scenario with reversed context manager order
+        with ModelMocker(Car), ModelMocker(Manufacturer):
+            create_delete_models()
+            assert not models_exist()
+
     def test_model_mocker_event_updated_from_manager(self):
         objects = {}
 


### PR DESCRIPTION
_Fixes #186_.

Ok, this was more involved than I anticipated. 

As explained in #186, `.delete()` operations on model instances within the scope of more than one `ModelMocker` is currently broken.

```python
with ModelMocker(Manufacturer), ModelMocker(Car, outer=False):
    car = Car.objects.create(speed=10)
    car.delete()

    manufacturer = Manufacturer.objects.create(name='foo')
    manufacturer.delete() # <-- Calls original Django delete method instead of deleting mock
```

The above would also fail for any model other than `Car`, which is the last `ModelMocker` in the context chain.

The underlying reason for this is the fact that a `ModelMocker` sets up two global or "shared" mocks for a pair of methods in `django.db.models.deletion.Collector`: `collect` and `delete`. They are re-used across all Django model instances to handle deletion, **regardless of whether they have been mocked or not**.

If declaring nested `ModelMocker` context managers, each one will attempt to set up the same "shared" mocks, overriding the last one. However, **the logic in place today is flawed** as, even though these particular mocks are supposed to be global,

* they [rely on local state and `MockSet` `objects` to resolve the `delete()` query](https://github.com/stphivos/django-mock-queries/blob/87362006e10f99a7f2120780b2018126026fe3df/django_mock_queries/mocks.py#L504).
* they fallback to invoking the original Django methods if the class of the model being deleted does not match **the class used to instantiate the _last_ `ModelMocker`** (i.e.: the innermost context manager or decorator). This is not right as `.delete()` may be called from any one mocked model.

In addition,

* a caller failing to pass `outer=False` to all mockers except the first, will cause **shared patchers to be prematurely stopped for _all_ managers and models**, likely resulting in failed tests.
* `ModelMocker` instances **are not thread-safe** and the result of running tests in parallel that rely on them is undetermined.
* Their internal state is shared between unit tests and is never reset after being initialised.

In order to fix this, I initially attempted to patch the existing logic — but, while doing so and trying to understand the implementation, I realised I couldn't fully grasp the original reason why these mocks needed to be "global" in the first place. I noticed this was done +7y ago by @stphivos, so I'm sure there were some factors behind the decision. There may be something that I'm missing here — please, let me know if there is.

In the end, I opted for simplifying the whole thing:

* **removed all "shared" mocks** completely;
* `outer=False` is **no longer needed** (passing it now is a no-op);
* declared a **local mock for the `delete` method**;
* explicitly mocked models will rely on `MockSet` to resolve their queries, while any others **will continue using Django as normal/expected**.

By removing any shared state, nesting and mixing any number of `ModelMocker` managers becomes a non-issue and the result is always predictable.