### PR TITLE
Remove universal wheel option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
 [metadata]
 description_file = README.md
-
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
Python 3 support has been dropped already, thus there is no need to build universal wheels.