### PR TITLE
Update dependencies and modernize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,37 +4,45 @@ on:
 - push
 - pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   main:
     strategy:
       matrix:
         include:
         - python: '3.9'
-          tox_env: 'py39-dj42-drf316'
+          tox_env: 'py39-dj42-drf317'
         - python: '3.10'
-          tox_env: 'py310-dj42-drf316'
+          tox_env: 'py310-dj52-drf318'
         - python: '3.11'
-          tox_env: 'py311-dj42-drf316'
+          tox_env: 'py311-dj52-drf318'
         - python: '3.12'
-          tox_env: 'py312-dj42-drf316'
-        - python: '3.10'
-          tox_env: 'py310-dj52-drf316'
-        - python: '3.11'
-          tox_env: 'py311-dj52-drf316'
-        - python: '3.12'
-          tox_env: 'py312-dj52-drf316'
+          tox_env: 'py312-dj52-drf318'
         - python: '3.13'
-          tox_env: 'py313-dj52-drf316'
+          tox_env: 'py313-dj52-drf318'
         - python: '3.14'
-          tox_env: 'py314-dj52-drf316'
+          tox_env: 'py314-dj52-drf318'
+        - python: '3.12'
+          tox_env: 'py312-dj61-drf318'
+        - python: '3.13'
+          tox_env: 'py313-dj61-drf318'
+        - python: '3.14'
+          tox_env: 'py314-dj61-drf318'
 
     runs-on: ubuntu-latest
     name: Python ${{ matrix.python }} with packages ${{ matrix.tox_env }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: ${{ matrix.python }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,17 +4,25 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
-        python-version: "3.x"
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+      with:
+        python-version: '3.x'
     - name: Install pypa/build
       run: >-
         python3 -m
@@ -24,7 +32,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: python-package-distributions
         path: dist/
@@ -42,9 +50,9 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,31 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["**"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054  # v0.6.2
+        with:
+          persona: pedantic

--- a/django_mock_queries/mocks.py
+++ b/django_mock_queries/mocks.py
@@ -458,7 +458,10 @@ class ModelMocker(Mocker):
         return []
 
     def _do_update(self, *args, **_):
-        _, _, pk_val, values, _, _ = args
+        if django.VERSION[0] >= 6:
+            _base_qs, _using, pk_val, values, _update_fields, _forced_update, _returning_fields = args
+        else:
+            _base_qs, _using, pk_val, values, _update_fields, _forced_update = args
         objects = self.objects.filter(pk=pk_val)
 
         if objects.exists():

--- a/django_mock_queries/mocks.py
+++ b/django_mock_queries/mocks.py
@@ -458,18 +458,20 @@ class ModelMocker(Mocker):
         return []
 
     def _do_update(self, *args, **_):
-        if django.VERSION[0] >= 6:
+        use_new_behavior = django.VERSION >= (6, 0)
+        if use_new_behavior:
+            # TODO: We might need to implement support for `returning_fields`.
             _base_qs, _using, pk_val, values, _update_fields, _forced_update, _returning_fields = args
         else:
             _base_qs, _using, pk_val, values, _update_fields, _forced_update = args
-        objects = self.objects.filter(pk=pk_val)
 
-        if objects.exists():
-            attrs = {field.attname: value for field, _, value in values if value is not None}
-            self.objects.update(**attrs)
-            return True
-        else:
-            return False
+        objects = self.objects.filter(pk=pk_val)
+        if not objects.exists():
+            return [] if use_new_behavior else False
+
+        attrs = {field.attname: value for field, _model, value in values if value is not None}
+        self.objects.update(**attrs)
+        return [()] if use_new_behavior else True
 
     def delete(self, *_args, **_kwargs):
         pk = self._obj_pk(self.objects[0])

--- a/django_mock_queries/mocks.py
+++ b/django_mock_queries/mocks.py
@@ -91,8 +91,11 @@ def mock_django_connection(disabled_features=None):
         result = MagicMock(name='mock_connection.ops.compiler()')
         # noinspection PyProtectedMember
         result.execute_sql.side_effect = NotSupportedError(
-            "Mock database tried to execute SQL for {} model.".format(
-                queryset.model._meta.object_name))
+            f"Mock database tried to execute SQL for {queryset.model._meta.object_name} model."
+        )
+        result.execute_returning_sql.side_effect = NotSupportedError(
+            f"Mock database tried to execute returning SQL for {queryset.model._meta.object_name} model."
+        )
         result.has_results.side_effect = result.execute_sql.side_effect
         return result
 

--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -352,7 +352,7 @@ class MockSet(MagicMock, metaclass=MockSetMeta):
                 value = flatten_list(value)
                 result_count = max(result_count, len(value))
 
-                for bucket, data in field_buckets.items():
+                for _bucket, data in field_buckets.items():
                     while len(data) < result_count:
                         data.append(data[-1])
 
@@ -508,7 +508,7 @@ class MockOptions:
         for key in ('local_concrete_fields', 'concrete_fields', 'fields'):
             self.__dict__[key] = []
 
-            for name, obj in fields.items():
+            for _name, obj in fields.items():
                 self.__dict__[key].append(obj)
 
 

--- a/django_mock_queries/utils.py
+++ b/django_mock_queries/utils.py
@@ -85,7 +85,7 @@ def find_field_names(obj, **kwargs):
 def validate_field(field_name, model_fields, for_update=False):
     if '__' in field_name and for_update:
         raise FieldError(
-            'Cannot update model field %r (only non-relations and foreign keys permitted).' % field_name
+            f'Cannot update model field {field_name!r} (only non-relations and foreign keys permitted).'
         )
     if field_name != 'pk' and field_name not in model_fields:
         message = "Cannot resolve keyword '{}' into field. Choices are {}.".format(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,10 +1,9 @@
-pytest==8.4.2
-pytest-cov==7.0.0
+pytest==8.4.2  # Last version for Python 3.9
+pytest-cov==7.1.0
 pytest-django
 flake8==7.3.0
 coverage==7.10.7
 tox==4.30.3
-virtualenv==20.36.1
-pypandoc==1.15
-setuptools==80.9.0
-twine==6.2.0
+virtualenv==21.7.7
+pypandoc==1.17
+setuptools==82.0.1

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read_md(filename):
 def parse_requirements(filename):
     reqs = Path(filename).read_text(encoding='utf-8').splitlines()
     if not reqs:
-        raise RuntimeError("Unable to read requirements from '%s'" % filename)
+        raise RuntimeError(f"Unable to read requirements from '{filename}'")
     return reqs
 
 
@@ -23,14 +23,13 @@ setup(
     url='https://github.com/stphivos/django-mock-queries',
     author='Phivos Stylianides',
     author_email='stphivos@gmail.com',
-    license='MIT',
+    license_expression='MIT',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Testing',
         'Topic :: Software Development :: Testing :: Mocking',
         'Topic :: Software Development :: Testing :: Unit',
-        'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3 :: Only',
     ],

--- a/tests/test_asserts.py
+++ b/tests/test_asserts.py
@@ -10,6 +10,7 @@ from tests.mock_models import Car, CarSerializer, Manufacturer
 
 class TestQuery(TestCase):
     def setUp(self):
+        super().setUp()
         self.make_model = baker.prepare(Manufacturer, id=1, _fill_optional=True)
         self.car_model = baker.prepare(Car, id=1, make=self.make_model, _fill_optional=True)
         self.serializer_assert = SerializerAssert(CarSerializer)
@@ -95,6 +96,6 @@ class TestQuery(TestCase):
     @skipIf(django.VERSION[:2] >= (1, 10),
             "Django 1.10 refreshes deleted fields from the database.")
     def test_serializer_assert_run_skips_check_for_null_field_excluded_from_serializer(self):
-        delattr(self.car_model, 'model')
+        del self.car_model.model
         sa = self.serializer_assert.instance(self.car_model).returns('model')
         sa.run()

--- a/tests/test_asserts.py
+++ b/tests/test_asserts.py
@@ -1,4 +1,4 @@
-from unittest import TestCase, skipIf
+from unittest import TestCase
 from unittest.mock import patch
 
 from model_bakery import baker

--- a/tests/test_asserts.py
+++ b/tests/test_asserts.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 
 from model_bakery import baker
 
-import django
 from django_mock_queries.asserts import assert_serializer, SerializerAssert
 from tests.mock_models import Car, CarSerializer, Manufacturer
 
@@ -91,11 +90,4 @@ class TestQuery(TestCase):
             'speed': self.car_model.format_speed()
         }
         sa = self.serializer_assert.instance(self.car_model).returns(*values.keys()).values(**values)
-        sa.run()
-
-    @skipIf(django.VERSION[:2] >= (1, 10),
-            "Django 1.10 refreshes deleted fields from the database.")
-    def test_serializer_assert_run_skips_check_for_null_field_excluded_from_serializer(self):
-        del self.car_model.model
-        sa = self.serializer_assert.instance(self.car_model).returns('model')
         sa.run()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -18,9 +18,11 @@ from tests.mock_models import Car, CarVariation, Sedan, Manufacturer
 
 class TestQuery(TestCase):
     def setUp(self):
+        super().setUp()
         self.mock_set = MockSet()
 
     def tearDown(self):
+        super().tearDown()
         self.mock_set.clear()
 
     def test_query_counts_items_in_set(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-# See https://docs.djangoproject.com/en/5.2/faq/install/#what-python-version-can-i-use-with-django
+# See https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 # EOL: https://endoflife.date/django
 envlist =
-    py{39,310,311,312}-dj42-drf{316}
-    py{310,311,312,313,314}-dj52-drf{316}
+    py{39}-dj42-drf{317}
+    py{310,311,312,313,314}-dj52-drf{318}
+    py{312,313,314}-dj61-drf{318}
 
 [pytest]
 norecursedirs = examples
@@ -18,11 +19,14 @@ constrain_package_deps = true
 use_frozen_constraints = false
 deps =
     -rrequirements/dev.txt
-    dj42: Django~=4.2.9
+    dj42: django~=4.2.0
     dj42: pytest-django~=4.11.0
-    dj52: Django~=5.2.0
-    dj52: pytest-django~=4.11.0
-    drf316: djangorestframework~=3.16.0
+    dj52: django~=5.2.0
+    dj52: pytest-django~=4.14.0
+    dj61: django~=6.1.0
+    dj61: pytest-django~=4.14.0
+    drf316: djangorestframework~=3.17.0
+    drf318: djangorestframework~=3.18.0
 
 commands =
     pytest django_mock_queries/ tests/ --cov-report term-missing --cov=django_mock_queries


### PR DESCRIPTION
This updates the dependencies to the latest versions and starts testing against Django 6.1 while Django 6.2 is not yet available. Although Django 4.2 is EOL now, I decided to keep it for Python 3.9 compatibility, while Python 3.9 is not yet EOL.

Another modernization has been done in the `setup.py` file to use the new license expressions instead of the deprecated trove classifiers and basic license field. I have added a `pyproject.toml` file with the build backend to use as well to satisfy the build process, although it is not a strict requirement.

Besides this, I decided to integrate the *zizmor* tooling into the CI workflows, which checks for common pitfalls inside the GitHub workflows itself. I have been using it in my other projects for quite some time and it helped with some bad practices, although it might be beneficial to enable Dependabot for updating GitHub Actios in the next step.

I fixed some basic linter findings as well as moving some formatting to f-strings as Python 3 is enforced for quite some time now.